### PR TITLE
[tests] Slightly simplified docker-compose.yml

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -8,22 +8,43 @@ use mordred to test all data sources supported in GrimoireLab.
 * requirements.cfg: sample file with the versions of GrimoireLab stack to be used
 * orgs_file: organizations file to be loaded in Sorting Hat for affiliations
 * cache-test.tgz: perceval cache for all data sources, mbox data and irc data.
-* docker-compose.yml: sample docker compose file to launch mordred
+* docker-compose.yml: minimum docker compose file to launch mordred
+* docker-compose-local.yml: example of additional local docker compose config file
 * stage: Script for testing for the mordred docker image
 
 So you just need to execute:
 
-```
-mkdir logs
-docker-compose up mordred
+```bash
+$ mkdir logs
+$ docker-compose up mordred
 ```
 
 In the logs/all.log file you can track the execution of mordred.
 
+The above command run the set of containers specified in the default
+configuration file `docker-compose.yml`.
+The one provided in this directory intends to be minimal,
+so that containers can be deployed with as a few constraints as possible.
+For example, it does not expose ElasticSearch or Kibana ports to the host.
+In case you want to do this, for example for accessing them from the host,
+run a local configuration override file. For example:
+
+```bash
+$ docker-compose -f docker-compose.yml -f docker-compose-local.yml up mordred
+```
+
+`docker-compose`, run as above, will redirect the output from all
+the containers to the stdout.
+If you want to avoid all those messages, you can just redirect them to file:
+
+```bash
+$ docker-compose up mordred > /tmp/log
+```
+
 If you want to enter the container to debug inside it, once the docker container
 is up and running execute:
 
-```
+```bash
 docker exec -t -i testing_mordred_1 env TERM=xterm /bin/bash
 ```
 

--- a/tests/docker-compose-local.yml
+++ b/tests/docker-compose-local.yml
@@ -1,0 +1,11 @@
+# Use it if you want testing data to be published locally
+# Change in setup.cfg the collection and enrichment ES urls
+# to url = http://elasticsearch:9200
+
+elasticsearch:
+  ports:
+    - "9200:9200"
+
+kibiter:
+  ports:
+    - "5601:5601"

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -5,8 +5,8 @@
 elasticsearch:
   image: bitergia/elasticsearch:5.6.0
   command: /elasticsearch/bin/elasticsearch -E network.bind_host=0.0.0.0
-  ports:
-    - "9200:9200"
+#  ports:
+#    - "9200:9200"
   environment:
     - ES_JAVA_OPTS=-Xms2g -Xmx2g
   # volumes:
@@ -16,8 +16,8 @@ kibiter:
   image: bitergia/kibiter:5.6.0
   links:
     - elasticsearch
-  ports:
-    - "5601:5601"
+#  ports:
+#    - "5601:5601"
   environment:
     # - ELASTICSEARCH_URL=http://172.17.0.1:9200
     - ELASTICSEARCH_USER=bitergia


### PR DESCRIPTION
The default configuration for docker-compose exposed the
Kibana and ElasticSearch ports to the host. This causes
trouble if there are local instances of any of them
already running in the host, or if those ports are busy
for some other reason.

To avoid this problem, docker-compose.yml now avoids
to expose those ports. But the functionality provided
by the previous docker-compose.yml file is still
provided by using -f option to docker-compose,
and docker-compose-local.yml, see current version of
README.md for details.