### PR TITLE
[tests] New mordred container

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,54 @@
+# Copyright (C) 2016-2017 Bitergia
+# GPLv3 License
+
+FROM debian:stretch-slim
+MAINTAINER Jesus M. Gonzalez-Barahona <jgb@bitergia.com>
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEPLOY_USER grimoirelab
+ENV DEPLOY_USER_DIR /home/${DEPLOY_USER}
+ENV SCRIPTS_DIR ${DEPLOY_USER_DIR}/scripts
+
+# Initial user
+RUN useradd ${DEPLOY_USER} --create-home --shell /bin/bash
+
+# install dependencies
+RUN apt-get update && \
+    apt-get -y install --no-install-recommends \
+        bash locales \
+        git git-core \
+        python3 \
+        python3-pip \
+        python3-venv \
+        mariadb-client \
+        unzip curl wget sudo ssh \
+        && \
+    apt-get clean && \
+    find /var/lib/apt/lists -type f -delete
+
+RUN echo "${DEPLOY_USER} ALL=NOPASSWD: ALL" >> /etc/sudoers
+
+RUN mkdir -p ${DEPLOY_USER_DIR}/logs ; chown -R ${DEPLOY_USER}:${DEPLOY_USER} ${DEPLOY_USER_DIR}/logs
+VOLUME ["/home/grimoirelog/logs"]
+
+ADD stage ${DEPLOY_USER_DIR}/stage
+RUN chmod 755 ${DEPLOY_USER_DIR}/stage
+
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+
+#ADD cacert.pem ${DEPLOY_USER_DIR}/cacert.pem
+#RUN CERT_PATH=`python3 -m requests.certs` && \
+#    cat ${DEPLOY_USER_DIR}/cacert.pem >> ${CERT_PATH}
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+ENV LANG C.UTF-8
+
+USER ${DEPLOY_USER}
+WORKDIR ${DEPLOY_USER_DIR}
+
+CMD ${DEPLOY_USER_DIR}/stage

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,7 +16,8 @@ So you just need to execute:
 
 ```bash
 $ mkdir logs
-$ docker-compose up mordred
+$ docker-compose rm mordred
+$ docker-compose up --force-recreate mordred
 ```
 
 In the logs/all.log file you can track the execution of mordred.
@@ -45,7 +46,7 @@ If you want to enter the container to debug inside it, once the docker container
 is up and running execute:
 
 ```bash
-docker exec -t -i testing_mordred_1 env TERM=xterm /bin/bash
+docker exec -t -i tests_mordred_1 env TERM=xterm /bin/bash
 ```
 
 # Panel testing
@@ -67,4 +68,14 @@ To check for a specific panel:
 
 ```
 python3 ~/devel/panels/src/owlwatch/owlwatch.py  compare-panel -e http://bitergia:bitergia@localhost:9200 -p ~/devel/panels/json/slack.json
+```
+
+# Creating grimoirelab Docker image
+
+`grimoirelab` is a basic Docker image, prepared for installing GrimoireLab
+tools in it. It's definition is in `Dockerfile`.
+For creating the image:
+
+```
+$ docker build -t grimoirelab/basic .
 ```

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -33,13 +33,14 @@ mariadb:
     command: --wait_timeout=2592000 --interactive_timeout=2592000 --max_connections=300
 
 mordred:
-  image: bitergia/mordred:latest
+  image: grimoirelab/basic:latest
   links:
     - mariadb
     - elasticsearch
     - kibiter
   volumes:
     # The stage for this mordred load raw items, waits for ES ...
-    - ./stage:/home/bitergia/stage
-    - .:/home/bitergia/conf
-    - ./logs:/home/bitergia/logs
+    - ./stage:/home/grimoirelab/stage
+    - .:/home/grimoirelab/conf
+    - ..:/home/grimoirelab/grimoirelab
+    - ./logs:/home/grimoirelab/logs

--- a/tests/stage
+++ b/tests/stage
@@ -1,131 +1,29 @@
 #!/bin/bash
 
-source /home/bitergia/conf/requirements.cfg
-
-# if RELEASE param is set, we download the info from
-# https://github.com/Bitergia/mordred/tree/master/docker/unified_releases/
-if [ $RELEASE ];
-    then
-    unset ARTHUR
-    unset GRIMOIREELK
-    unset GRIMOIRELAB_TOOLKIT
-    unset MORDRED
-    unset PANELS
-    unset PERCEVAL
-    unset PERCEVAL_MOZILLA
-    unset PERCEVAL_OPNFV
-    unset SORTINGHAT
-    unset REPORTS
-    TMPFILE=`mktemp`
-    wget https://raw.githubusercontent.com/Bitergia/mordred/master/docker/unified_releases/$RELEASE -O $TMPFILE
-    source $TMPFILE
-    rm $TMPFILE
-    echo $RELEASE > /home/bitergia/release
-else
-    echo "customized release, see requirements.cfg file" > /home/bitergia/release
-fi
-
-# get Arthur repository
-cd /home/bitergia && \
-# git clone https://github.com/grimoirelab/arthur.git && \
-git clone https://github.com/acs/arthur.git && \
-    cd arthur && \
-    git checkout $ARTHUR && \
-    sudo python3 setup.py install
-
-# get SortingHat repository
-cd /home/bitergia && \
-git clone https://github.com/grimoirelab/sortinghat.git && \
-    cd sortinghat && \
-    git checkout $SORTINGHAT && \
-    sudo python3 setup.py install
-
-# get GrimoireELK repository
-cd /home/bitergia && \
-git clone https://github.com/grimoirelab/GrimoireELK && \
-    cd GrimoireELK && \
-    git checkout $GRIMOIREELK
-
-# get Mordred repository
-cd /home/bitergia && \
-git clone https://github.com/Bitergia/mordred.git mordred && \
-    cd mordred && \
-    git checkout $MORDRED
-
-# panels for the dashboard
-cd /home/bitergia && \
-git clone https://github.com/grimoirelab/panels.git panels && \
-    cd panels && \
-    git checkout $PANELS
-
-# reports repository
-cd /home/bitergia && \
-git clone https://github.com/grimoirelab/reports.git reports && \
-    cd reports && \
-    git checkout $REPORTS
-
-# get GrimoireLab Toolkit repository
-cd /home/bitergia && \
-git clone https://github.com/grimoirelab/grimoirelab-toolkit.git && \
-    cd grimoirelab-toolkit && \
-    git checkout $GRIMOIRELAB_TOOLKIT && \
-    sudo python3 setup.py install
-
-# get Perceval repository
-cd /home/bitergia && \
-    git clone https://github.com/grimoirelab/perceval.git && \
-    cd perceval && \
-    git checkout $PERCEVAL && \
-    sudo python3 setup.py install
-
-# perceval extras
-cd /home/bitergia && \
-    git clone https://github.com/grimoirelab/perceval-mozilla && \
-    cd perceval-mozilla && \
-    git checkout $PERCEVAL_MOZILLA && \
-    sudo python3 setup.py install
-
-cd /home/bitergia && \
-    git clone https://github.com/grimoirelab/perceval-puppet && \
-    cd perceval-puppet && \
-    git checkout $PERCEVAL_PUPPET && \
-    sudo python3 setup.py install
-
-cd /home/bitergia && \
-    git clone https://github.com/grimoirelab/perceval-opnfv && \
-    cd perceval-opnfv && \
-    git checkout $PERCEVAL_OPNFV && \
-    sudo python3 setup.py install
-
-
-# some links we need until GrimoireELK and panels can be installed
-ln -s /home/bitergia/GrimoireELK/grimoire /home/bitergia/mordred/grimoire
-ln -s /home/bitergia/GrimoireELK/grimoire_elk /home/bitergia/mordred/grimoire_elk
-ln -s /home/bitergia/panels /home/bitergia/mordred/panels
-ln -s /home/bitergia/panels/dashboards5 /home/bitergia/panels/dashboards
+echo "Installing and checking GrimoireLab"
+sudo grimoirelab/utils/build_grimoirelab --build --install --check --install_system
 
 # This could be an ENV var probably
-REDIS="redis"
+#REDIS="redis"
 
 # arthur on
-arthurd -g -d redis://$REDIS/8 --es-index $ARTHUR_ELASTICSEARCH_INDEX --log-path /home/bitergia/logs/arthurd --no-cache
+#arthurd -g -d redis://$REDIS/8 --es-index $ARTHUR_ELASTICSEARCH_INDEX --log-path /home/bitergia/logs/arthurd --no-cache
 # Give time to arthur to create the raw index
-echo "Waiting for arthur startup completion ..."
-sleep 5
-echo "Starting two workers: collect and update tasks"
+#echo "Waiting for arthur startup completion ..."
+#sleep 5
+#echo "Starting two workers: collect and update tasks"
 # Two workers
-(arthurw -g -d redis://$REDIS/8 > /home/bitergia/logs/worker-collect.log 2>&1) &
-(arthurw -g -d redis://$REDIS/8 update > /home/bitergia/logs/worker-update.log 2>&1) &
-# some links we need until GrimoireELK and panels and reports can be installed
-ln -s /home/bitergia/GrimoireELK/grimoire /home/bitergia/mordred/grimoire
-ln -s /home/bitergia/GrimoireELK/grimoire_elk /home/bitergia/mordred/grimoire_elk
-ln -s /home/bitergia/panels /home/bitergia/mordred/panels
-ln -s /home/bitergia/reports /home/bitergia/mordred/reports
+#(arthurw -g -d redis://$REDIS/8 > /home/bitergia/logs/worker-collect.log 2>&1) &
+#(arthurw -g -d redis://$REDIS/8 update > /home/bitergia/logs/worker-update.log 2>&1) &
+
+mkdir /home/grimoirelab/mordred
+ln -s /home/grimoirelab/panels /home/grimoirelab/mordred/panels
+#ln -s /home/bitergia/reports /home/bitergia/mordred/reports
 
 # Extracting the perceval cache
 echo "Extracting the perceval cache data ..."
-cd /home/bitergia/conf && tar xfz cache-test.tgz
-ln -s /home/bitergia/conf/perceval-cache /home/bitergia/.perceval
+cd /home/grimoirelab/conf && tar xfz cache-test.tgz
+ln -s /home/grimoirelab/conf/perceval-cache /home/bitergia/.perceval
 
 # Wait for Elasticsearch
 echo "Waiting for elasticsearch startup completion ..."
@@ -136,7 +34,7 @@ done
 echo "Elasticsearch OK"
 # Load raw data
 echo "Loading initial raw data ..."
-cd /home/bitergia/conf && ./init-raw.sh
+cd /home/grimoirelab/conf && ./init-raw.sh
 # We need to wait also for Kibiter so the version can be collected
 echo "Waiting for kibiter startup completion ..."
 until $(curl --output /dev/null --silent --head --fail http://172.17.0.1:5601); do
@@ -144,5 +42,4 @@ until $(curl --output /dev/null --silent --head --fail http://172.17.0.1:5601); 
     sleep 5
 done
 echo "Kibiter OK"
-cd /home/bitergia/mordred && \
-bin/mordred -c /home/bitergia/conf/setup.cfg
+cd /home/grimoirelab && mordred -c conf/setup.cfg

--- a/utils/build_grimoirelab
+++ b/utils/build_grimoirelab
@@ -37,7 +37,7 @@ Example:
 """
 
 build_dependencies = ['pip', 'setuptools', 'pypandoc', 'twine']
-install_dependencies = ['pip']
+install_dependencies = ['pip', 'setuptools']
 
 all_repos = {
     'grimoirelab-toolkit': [{'name': 'grimoirelab-toolkit', 'dir': '',
@@ -105,7 +105,7 @@ def parse_args ():
                                 + "installed in it in their latest version."
                                 + "If not specified, create a random directory, "
                                 + "which will be cleaned up when done.")
-    args_venv.add_argument("--system", type=str,
+    args_venv.add_argument("--system", action='store_true',
                             help="Use Python3 system environment, instead of "
                                 + "a virtual environment, for building "
                                 + "packages. It should include all dependencies "
@@ -270,7 +270,7 @@ class Venv (CommandRunner):
             self.dir = Directory(name=name, purpose=purpose, persistent=persistent)
             self.name = self.dir.name
             self._create ()
-            self.update (module_names=dependencies)
+        self.update (module_names=dependencies)
 
     def _create(self):
 
@@ -517,7 +517,7 @@ def main():
 
     if args.install:
         print("Installing...")
-        install_venv = Venv(system=args.system, name=args.install_venv,
+        install_venv = Venv(system=args.install_system, name=args.install_venv,
                         dependencies=install_dependencies,
                         purpose="InstallVenv", persistent=True)
         install_venv.update(module_names=modules.names(),


### PR DESCRIPTION
This patch changes:

* The base container used for the mordred service in docker-compose.
  Now, it is based on Debian9 (since the script below needs
  Python3.5), and only minimal packages are installed
  (including almost no Python modules, which will be installed later).

* The docker-compose file is simplified, using the
  utils/build_grimoirelab script.

* The utils/build_grimoirelab script was fixed to work well when
  installing in the system (instead of in a virtual environment).

* tests/README.md is updated to reflect some of these changes.

For now, it only installs the master/HEAD for all GrimoireLab repos,
but it could be easily modified to install any coordinanted
release.