### PR TITLE
[tests] Fix docker cointainers configuration info

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -16,10 +16,12 @@ RUN useradd ${DEPLOY_USER} --create-home --shell /bin/bash
 RUN apt-get update && \
     apt-get -y install --no-install-recommends \
         bash locales \
+        gcc \
         git git-core \
         python3 \
         python3-pip \
         python3-venv \
+        python3-dev \
         mariadb-client \
         unzip curl wget sudo ssh \
         && \

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -5,12 +5,12 @@
 elasticsearch:
   image: bitergia/elasticsearch:5.6.0
   command: /elasticsearch/bin/elasticsearch -E network.bind_host=0.0.0.0
-#  ports:
-#    - "9200:9200"
+  ports:
+    - "9200:9200"
   environment:
     - ES_JAVA_OPTS=-Xms2g -Xmx2g
-  # volumes:
-    #- ./elasticsearch.yml:/elasticsearch/config/elasticsearch.yml
+  volumes:
+    - ./elasticsearch.yml:/elasticsearch/config/elasticsearch.yml
 
 kibiter:
   image: bitergia/kibiter:5.6.0

--- a/tests/stage
+++ b/tests/stage
@@ -23,7 +23,7 @@ ln -s /home/grimoirelab/panels /home/grimoirelab/mordred/panels
 # Extracting the perceval cache
 echo "Extracting the perceval cache data ..."
 cd /home/grimoirelab/conf && tar xfz cache-test.tgz
-ln -s /home/grimoirelab/conf/perceval-cache /home/bitergia/.perceval
+ln -s /home/grimoirelab/conf/perceval-cache /home/grimoirelab/.perceval
 
 # Wait for Elasticsearch
 echo "Waiting for elasticsearch startup completion ..."

--- a/utils/build_grimoirelab
+++ b/utils/build_grimoirelab
@@ -36,8 +36,8 @@ Example:
 
 """
 
-build_dependencies = ['pip', 'setuptools', 'pypandoc', 'twine']
-install_dependencies = ['pip', 'setuptools']
+build_dependencies = ['pip', 'setuptools', 'pypandoc', 'twine', 'wheel']
+install_dependencies = ['pip', 'setuptools', 'wheel']
 
 all_repos = {
     'grimoirelab-toolkit': [{'name': 'grimoirelab-toolkit', 'dir': '',


### PR DESCRIPTION
Dependencies could not be installed from wheels because the wheel package was not installed. This patch installs it. A new Python dependency is not available in binary wheels, so it needs to be compiled. But there was no compiler in the base container. So, this patch installs it.
There are some other (hopefully minor) issues fixed too.

Please, try this from scratch, as follows:

```
$ docker build -t grimoirelab/basic .
$ docker-compose -f docker-compose.yml -f docker-compose-local.yml mordred
```

(although it is very likely that you really don't need the two `-f` parameters in the second command)

This is a quick patch, trying to make the stuff work. I'm still working in more testing and a better solution.