### PR TITLE
[2.x] Support generating alpha releases for GrimoireLab

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -32,6 +32,9 @@ jobs:
           tags: |
             # Generate a raw tag so latest is not used
             type=raw,value=${{ inputs.version }}
+            type=raw,value=2.x
+          build-args: |
+            GRIMOIRELAB_RELEASE=${{ inputs.version }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0

--- a/.github/workflows/grimoirelab-release.yml
+++ b/.github/workflows/grimoirelab-release.yml
@@ -1,13 +1,26 @@
+# Basic workflow to release GrimoireLab 2.x-alpha releases
+# For this workflow all the versions are prereleases
+
+
 name: GrimoireLab release
 
 on:
   workflow_dispatch:
     inputs:
-      release_candidate:
-        description: "Create a release candidate version"
+      prerelease:
+        description: "Create a pre-release version"
         required: true
         type: boolean
         default: false
+      prerelease_label:
+        description: "Label for pre-release"
+        required: false
+        type: choice
+        options:
+          - alpha
+          - beta
+          - rc
+        default: rc
       bump_major:
         description: "Create a major version release"
         required: true
@@ -29,33 +42,18 @@ jobs:
     outputs:
       git_email: ${{ steps.variables.outputs.git_email }}
       git_name: ${{ steps.variables.outputs.git_name }}
-      release_candidate: ${{ steps.variables.outputs.release_candidate }}
+      prerelease: ${{ steps.variables.outputs.prerelease }}
+      prerelease_label: ${{ inputs.prerelease_label }}
       bump_major: ${{ steps.variables.outputs.bump_major }}
     steps:
       - id: variables
         name: variables
         run: |
           echo "git_email=${{ inputs.git_email }}" >> $GITHUB_OUTPUT
-          echo "git_name=${{ inputs.git_name}}" >> $GITHUB_OUTPUT
-          echo "release_candidate=${{ inputs.release_candidate}}" >> $GITHUB_OUTPUT
-          echo "bump_major=${{ inputs.bump_major}}" >> $GITHUB_OUTPUT
-
-  grimoirelab-toolkit:
-    name: grimoirelab-toolkit
-    needs:
-      - variables-job
-    uses: ./.github/workflows/release-grimoirelab-component.yml
-    with:
-      git_email: ${{ needs.variables-job.outputs.git_email }}
-      git_name: ${{ needs.variables-job.outputs.git_name }}
-      release_candidate: ${{ needs.variables-job.outputs.release_candidate }}
-      bump_major: ${{ needs.variables-job.outputs.bump_major }}
-      module_name: 'grimoirelab-toolkit'
-      module_repository: 'chaoss/grimoirelab-toolkit'
-      module_directory: 'src/grimoirelab-toolkit'
-      dependencies: ''
-    secrets:
-      access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
+          echo "git_name=${{ inputs.git_name }}" >> $GITHUB_OUTPUT
+          echo "prerelease=${{ inputs.prerelease }}" >> $GITHUB_OUTPUT
+          echo "prerelease_label=${{ inputs.prerelease_label }}" >> $GITHUB_OUTPUT
+          echo "bump_major=${{ inputs.bump_major }}" >> $GITHUB_OUTPUT
 
   grimoirelab-chronicler:
     name: chronicler
@@ -65,7 +63,8 @@ jobs:
     with:
       git_email: ${{ needs.variables-job.outputs.git_email }}
       git_name: ${{ needs.variables-job.outputs.git_name }}
-      release_candidate: ${{ needs.variables-job.outputs.release_candidate }}
+      prerelease: ${{ needs.variables-job.outputs.prerelease }}
+      prerelease_label: ${{ needs.variables-job.outputs.prerelease_label }}
       bump_major: ${{ needs.variables-job.outputs.bump_major }}
       module_name: 'grimoirelab-chronicler'
       module_repository: 'grimoirelab/grimoirelab-chronicler'
@@ -74,141 +73,22 @@ jobs:
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
-  grimoirelab-sortinghat:
-    name: Sortinghat
-    needs:
-      - variables-job
-      - grimoirelab-toolkit
-    uses: ./.github/workflows/release-grimoirelab-component.yml
-    with:
-      git_email: ${{ needs.variables-job.outputs.git_email }}
-      git_name: ${{ needs.variables-job.outputs.git_name }}
-      release_candidate: ${{ needs.variables-job.outputs.release_candidate }}
-      bump_major: ${{ needs.variables-job.outputs.bump_major }}
-      module_name: 'sortinghat'
-      module_repository: 'chaoss/grimoirelab-sortinghat'
-      module_directory: 'src/grimoirelab-sortinghat'
-      dependencies: '${{ needs.grimoirelab-toolkit.outputs.package_version }}'
-    secrets:
-      access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
-
-  grimoirelab-perceval:
-    name: Perceval
-    needs:
-      - variables-job
-      - grimoirelab-toolkit
-    uses: ./.github/workflows/release-grimoirelab-component.yml
-    with:
-      git_email: ${{ needs.variables-job.outputs.git_email }}
-      git_name: ${{ needs.variables-job.outputs.git_name }}
-      release_candidate: ${{ needs.variables-job.outputs.release_candidate }}
-      bump_major: ${{ needs.variables-job.outputs.bump_major }}
-      module_name: 'perceval'
-      module_repository: 'chaoss/grimoirelab-perceval'
-      module_directory: 'src/grimoirelab-perceval'
-      dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }}"
-    secrets:
-      access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
-
-  grimoirelab-perceval-mozilla:
-    name: Perceval Mozilla
-    needs:
-      - variables-job
-      - grimoirelab-toolkit
-      - grimoirelab-perceval
-    uses: ./.github/workflows/release-grimoirelab-component.yml
-    with:
-      git_email: ${{ needs.variables-job.outputs.git_email }}
-      git_name: ${{ needs.variables-job.outputs.git_name }}
-      release_candidate: ${{ needs.variables-job.outputs.release_candidate }}
-      bump_major: ${{ needs.variables-job.outputs.bump_major }}
-      module_name: 'perceval-mozilla'
-      module_repository: 'chaoss/grimoirelab-perceval-mozilla'
-      module_directory: 'src/grimoirelab-perceval-mozilla'
-      dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }} \
-      ${{ needs.grimoirelab-perceval.outputs.package_version }}"
-    secrets:
-      access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
-
-  grimoirelab-perceval-opnfv:
-    name: Perceval OPNFV
-    needs:
-      - variables-job
-      - grimoirelab-toolkit
-      - grimoirelab-perceval
-    uses: ./.github/workflows/release-grimoirelab-component.yml
-    with:
-      git_email: ${{ needs.variables-job.outputs.git_email }}
-      git_name: ${{ needs.variables-job.outputs.git_name }}
-      release_candidate: ${{ needs.variables-job.outputs.release_candidate }}
-      bump_major: ${{ needs.variables-job.outputs.bump_major }}
-      module_name: 'perceval-opnfv'
-      module_repository: 'chaoss/grimoirelab-perceval-opnfv'
-      module_directory: 'src/grimoirelab-perceval-opnfv'
-      dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }} \
-      ${{ needs.grimoirelab-perceval.outputs.package_version }}"
-    secrets:
-      access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
-
-  grimoirelab-perceval-puppet:
-    name: Perceval Puppet
-    needs:
-      - variables-job
-      - grimoirelab-toolkit
-      - grimoirelab-perceval
-    uses: ./.github/workflows/release-grimoirelab-component.yml
-    with:
-      git_email: ${{ needs.variables-job.outputs.git_email }}
-      git_name: ${{ needs.variables-job.outputs.git_name }}
-      release_candidate: ${{ needs.variables-job.outputs.release_candidate }}
-      bump_major: ${{ needs.variables-job.outputs.bump_major }}
-      module_name: 'perceval-puppet'
-      module_repository: 'chaoss/grimoirelab-perceval-puppet'
-      module_directory: 'src/grimoirelab-perceval-puppet'
-      dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }} \
-      ${{ needs.grimoirelab-perceval.outputs.package_version }}"
-    secrets:
-      access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
-
-  grimoirelab-perceval-weblate:
-    name: Perceval Weblate
-    needs:
-      - variables-job
-      - grimoirelab-toolkit
-      - grimoirelab-perceval
-    uses: ./.github/workflows/release-grimoirelab-component.yml
-    with:
-      git_email: ${{ needs.variables-job.outputs.git_email }}
-      git_name: ${{ needs.variables-job.outputs.git_name }}
-      release_candidate: ${{ needs.variables-job.outputs.release_candidate }}
-      bump_major: ${{ needs.variables-job.outputs.bump_major }}
-      module_name: 'perceval-weblate'
-      module_repository: 'chaoss/grimoirelab-perceval-weblate'
-      module_directory: 'src/grimoirelab-perceval-weblate'
-      dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }} \
-      ${{ needs.grimoirelab-perceval.outputs.package_version }}"
-    secrets:
-      access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
-
   grimoirelab-core:
     name: GrimoireLab Core
     needs:
       - variables-job
-      - grimoirelab-toolkit
       - grimoirelab-chronicler
-      - grimoirelab-perceval
     uses: ./.github/workflows/release-grimoirelab-component.yml
     with:
       git_email: ${{ needs.variables-job.outputs.git_email }}
       git_name: ${{ needs.variables-job.outputs.git_name }}
-      release_candidate: ${{ needs.variables-job.outputs.release_candidate }}
+      prerelease: ${{ needs.variables-job.outputs.prerelease }}
+      prerelease_label: ${{ needs.variables-job.outputs.prerelease_label }}
       bump_major: ${{ needs.variables-job.outputs.bump_major }}
       module_name: 'grimoirelab-core'
       module_repository: 'grimoirelab/grimoirelab-core'
       module_directory: 'src/grimoirelab-core'
-      dependencies: "${{ needs.grimoirelab-toolkit.outputs.package_version }} \
-      ${{ needs.grimoirelab-chronicler.outputs.package_version }} \
-      ${{ needs.grimoirelab-perceval.outputs.package_version }}"
+      dependencies: "${{ needs.grimoirelab-chronicler.outputs.package_version }}"
     secrets:
       access_token: ${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}
 
@@ -218,24 +98,17 @@ jobs:
     environment: grimoire-release
     needs:
       - variables-job
-      - grimoirelab-toolkit
       - grimoirelab-chronicler
-      - grimoirelab-sortinghat
-      - grimoirelab-perceval
-      - grimoirelab-perceval-mozilla
-      - grimoirelab-perceval-opnfv
-      - grimoirelab-perceval-puppet
-      - grimoirelab-perceval-weblate
       - grimoirelab-core
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           token: '${{ secrets.GRIMOIRELAB_BUILD_TOKEN }}'
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Set up Git config
         run: |
@@ -244,9 +117,7 @@ jobs:
 
       - name: Install poetry
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
-        shell: bash
+          pipx install poetry
 
       - name: Install release-tools
         #TODO: Change to the latest version once the new release is created
@@ -260,14 +131,7 @@ jobs:
       - id: semverup
         name: Update version number
         env:
-          grimoirelab_toolkit_version: "${{ needs.grimoirelab-toolkit.outputs.version}}"
           chronicler_version: "${{ needs.grimoirelab-chronicler.outputs.version}}"
-          sortinghat_version: "${{ needs.grimoirelab-sortinghat.outputs.version}}"
-          perceval_version: "${{ needs.grimoirelab-perceval.outputs.version}}"
-          perceval_mozilla_version: "${{ needs.grimoirelab-perceval-mozilla.outputs.version}}"
-          perceval_opnfv_version: "${{ needs.grimoirelab-perceval-opnfv.outputs.version}}"
-          perceval_puppet_version: "${{ needs.grimoirelab-perceval-puppet.outputs.version}}"
-          perceval_weblate_version: "${{ needs.grimoirelab-perceval-weblate.outputs.version}}"
           grimoirelab_core_version: "${{ needs.grimoirelab-core.outputs.version}}"
         run: |
           BUMP_MAJOR=4
@@ -305,19 +169,12 @@ jobs:
             poetry show -l $pkg | grep version | head -1 | awk '{print $3}'
           }
           
-          pkgs=("grimoirelab-toolkit"
-          "chronicler"
-          "sortinghat"
-          "perceval"
-          "perceval-mozilla"
-          "perceval-opnfv"
-          "perceval-puppet"
-          "perceval-weblate"
+          pkgs=("chronicler"
           "grimoirelab-core")
           
-          if [ ${{ inputs.release_candidate }} == 'true' ]
+          if [ ${{ inputs.prerelease }} == 'true' ]
           then
-            rcArg='--pre-release'
+            rcArg='--pre-release --pre-release-label=${{ inputs.prerelease_label }}'
           else
             rcArg=''
           fi
@@ -335,7 +192,10 @@ jobs:
           
           echo $versionUpdated
           
-          if [ $((versionUpdated & $BUMP_MAJOR )) -ne 0 ]
+          if [ ${{ inputs.bump_major }} == 'true' ]
+          then
+            version=$(semverup --bump-version=major $rcArg)
+          elif [ $((versionUpdated & $BUMP_MAJOR )) -ne 0 ]
           then
             version=$(semverup --bump-version=major $rcArg)
           elif [ $((versionUpdated & $BUMP_MINOR )) -ne 0 ]
@@ -351,35 +211,12 @@ jobs:
       - name: Update dependencies files
         run: |
           poetry add --lock --allow-prereleases \
-              "${{ needs.grimoirelab-toolkit.outputs.package_version }}" \
               "${{ needs.grimoirelab-chronicler.outputs.package_version }}" \
-              "${{ needs.grimoirelab-sortinghat.outputs.package_version }}" \
-              "${{ needs.grimoirelab-perceval.outputs.package_version }}" \
-              "${{ needs.grimoirelab-perceval-mozilla.outputs.package_version }}" \
-              "${{ needs.grimoirelab-perceval-opnfv.outputs.package_version }}" \
-              "${{ needs.grimoirelab-perceval-puppet.outputs.package_version }}" \
-              "${{ needs.grimoirelab-perceval-weblate.outputs.package_version }}" \
               "${{ needs.grimoirelab-core.outputs.package_version }}"
           poetry update --lock
 
-          cat << EOF > requirements.txt
-          grimoirelab==${{ steps.semverup.outputs.version }}
-          grimoirelab-toolkit==${{ needs.grimoirelab-toolkit.outputs.version }}
-          grimoirelab-chronicler==${{ needs.grimoirelab-chronicler.outputs.version }}
-          perceval==${{ needs.grimoirelab-perceval.outputs.version }}
-          perceval-mozilla==${{ needs.grimoirelab-perceval-mozilla.outputs.version }}
-          perceval-opnfv==${{ needs.grimoirelab-perceval-opnfv.outputs.version }}
-          perceval-puppet==${{ needs.grimoirelab-perceval-puppet.outputs.version }}
-          perceval-weblate==${{ needs.grimoirelab-perceval-weblate.outputs.version }}
-          sortinghat==${{ needs.grimoirelab-sortinghat.outputs.version }}
-          grimoirelab-core==${{ needs.grimoirelab-core.outputs.version }}
-          EOF
-
-          cat requirements.txt
-
           git add pyproject.toml
           git add poetry.lock
-          git add requirements.txt
 
       - name: Use custom release notes if exists
         id: custom_notes
@@ -395,7 +232,7 @@ jobs:
             echo "Using custom release file"
             
             # News file
-            if [ ${{ inputs.release_candidate }} == 'false' ]
+            if [ ${{ inputs.prerelease }} == 'false' ]
             then
               mv $news_file $old_news
               touch $news_file
@@ -418,14 +255,7 @@ jobs:
       - name: Generate release notes from packages
         if: steps.custom_notes.outputs.custom_notes == 'false'
         env:
-          grimoirelab_toolkit_notes: "${{ needs.grimoirelab-toolkit.outputs.notes}}"
           grimoirelab_chronicler_notes: "${{ needs.grimoirelab-chronicler.outputs.notes}}"
-          grimoirelab_sortinghat_notes: "${{ needs.grimoirelab-sortinghat.outputs.notes}}"
-          grimoirelab_perceval_notes: "${{ needs.grimoirelab-perceval.outputs.notes}}"
-          grimoirelab_perceval_mozilla_notes: "${{ needs.grimoirelab-perceval-mozilla.outputs.notes}}"
-          grimoirelab_perceval_opnfv_notes: "${{ needs.grimoirelab-perceval-opnfv.outputs.notes}}"
-          grimoirelab_perceval_puppet_notes: "${{ needs.grimoirelab-perceval-puppet.outputs.notes}}"
-          grimoirelab_perceval_weblate_notes: "${{ needs.grimoirelab-perceval-weblate.outputs.notes}}"
           grimoirelab_core_notes: "${{ needs.grimoirelab-core.outputs.notes}}"
         run: |
           version=${{ steps.semverup.outputs.version }}
@@ -436,39 +266,18 @@ jobs:
           # GrimoireLab $version
           The following list describes the changes by component:
 
-          $grimoirelab_toolkit_notes
           $grimoirelab_chronicler_notes
-          $grimoirelab_sortinghat_notes
-          $grimoirelab_perceval_notes
-          $grimoirelab_perceval_mozilla_notes
-          $grimoirelab_perceval_opnfv_notes
-          $grimoirelab_perceval_puppet_notes
-          $grimoirelab_perceval_weblate_notes
           $grimoirelab_core_notes
           $eof
 
           cat $release_file
 
       - name: Generate NEWS from packages
-        if: inputs.release_candidate == false && steps.custom_notes.outputs.custom_notes == 'false'
+        if: steps.custom_notes.outputs.custom_notes == 'false'
         env:
-          notes_grimoirelab_toolkit: "${{ needs.grimoirelab-toolkit.outputs.notes}}"
           notes_chronicler: "${{ needs.grimoirelab-chronicler.outputs.notes}}"
-          notes_sortinghat: "${{ needs.grimoirelab-sortinghat.outputs.notes}}"
-          notes_perceval: "${{ needs.grimoirelab-perceval.outputs.notes}}"
-          notes_perceval_mozilla: "${{ needs.grimoirelab-perceval-mozilla.outputs.notes}}"
-          notes_perceval_opnfv: "${{ needs.grimoirelab-perceval-opnfv.outputs.notes}}"
-          notes_perceval_puppet: "${{ needs.grimoirelab-perceval-puppet.outputs.notes}}"
-          notes_perceval_weblate: "${{ needs.grimoirelab-perceval-weblate.outputs.notes}}"
           notes_grimoirelab_core: "${{ needs.grimoirelab-core.outputs.notes}}"
-          version_grimoirelab_toolkit: "${{ needs.grimoirelab-toolkit.outputs.version }}"
           version_chronicler: "${{ needs.grimoirelab-chronicler.outputs.version }}"
-          version_sortinghat: "${{ needs.grimoirelab-sortinghat.outputs.version }}"
-          version_perceval: "${{ needs.grimoirelab-perceval.outputs.version }}"
-          version_perceval_mozilla: "${{ needs.grimoirelab-perceval-mozilla.outputs.version }}"
-          version_perceval_opnfv: "${{ needs.grimoirelab-perceval-opnfv.outputs.version }}"
-          version_perceval_puppet: "${{ needs.grimoirelab-perceval-puppet.outputs.version }}"
-          version_perceval_weblate: "${{ needs.grimoirelab-perceval-weblate.outputs.version }}"
           version_grimoirelab_core: "${{ needs.grimoirelab-core.outputs.version }}"
         run: |
           version=${{ steps.semverup.outputs.version }}
@@ -478,14 +287,7 @@ jobs:
           today=$(date -u "+%Y-%m-%d")
           
           packages=(
-          grimoirelab_toolkit
           chronicler
-          sortinghat
-          perceval
-          perceval_mozilla
-          perceval_opnfv
-          perceval_puppet
-          perceval_weblate
           grimoirelab_core
           )
           
@@ -529,12 +331,12 @@ jobs:
           cat $news_file
 
       - name: Update Dockerfile version
-        if: inputs.release_candidate == false
+        # if: inputs.prerelease == false
         run: |
           version=${{ steps.semverup.outputs.version }}
           dockerfile="docker/Dockerfile"
 
-          sed -i "s/ENV GRIMOIRELAB_RELEASE .*/ENV GRIMOIRELAB_RELEASE \"$version\"/" $dockerfile
+          sed -i "s/ARG GRIMOIRELAB_RELEASE=.*/ARG GRIMOIRELAB_RELEASE=\"$version\"/" $dockerfile
           git add $dockerfile
 
           cat $dockerfile
@@ -557,7 +359,7 @@ jobs:
         name: Publish new version.
         if: steps.semverup.outcome == 'success'
         run: |
-          if [ ${{ inputs.release_candidate }} == 'true' ]
+          if [ ${{ inputs.prerelease }} == 'true' ]
           then
             publish ${{ steps.semverup.outputs.version }} "${{ inputs.git_name }} <${{ inputs.git_email }}>" \
               --push origin --remote-branch ${GITHUB_REF#refs/heads/} --no-cleanup

--- a/.github/workflows/release-grimoirelab-component.yml
+++ b/.github/workflows/release-grimoirelab-component.yml
@@ -11,14 +11,20 @@ on:
         description: 'Git config name'
         type: string
         required: true
-      release_candidate:
-        description: 'Create a release candidate version'
+      prerelease:
+        description: 'Create a prerelease version'
         type: string
         required: true
+      prerelease_label:
+        description: 'Label for the prerelease version'
+        type: string
+        required: false
+        default: 'rc'
       bump_major:
         description: 'Create a new major version release'
         type: string
-        required: true
+        required: false
+        default: 'false'
       module_name:
         description: 'Name of the module'
         type: string
@@ -63,10 +69,10 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name: Set up Python 3.11
+      - name: Set up Python
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Set up Git config
         run: |
@@ -83,10 +89,9 @@ jobs:
           cd ${{ inputs.module_directory }}
           git checkout main
 
-      - name: Install poetry
+      - name: Install Poetry
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
+          pipx install poetry
         shell: bash
 
       - name: Install release-tools
@@ -143,9 +148,9 @@ jobs:
         continue-on-error: true
         shell: bash {0}
         run: |
-          if [ ${{ inputs.release_candidate }} == 'true' ]
+          if [ ${{ inputs.prerelease }} == 'true' ]
           then
-            rcArg='--pre-release'
+            rcArg='--pre-release --pre-release-label ${{ inputs.prerelease_label }}'
           else
             rcArg=''
           fi
@@ -164,9 +169,9 @@ jobs:
             echo "Dependencies updated, force new version"
             version=$(semverup --bump-version patch $rcArg)
             echo "forced_version=true" >> $GITHUB_OUTPUT
-          elif [ -z $version ] && [ ${{ inputs.release_candidate }} != 'true' ] && [[ "$old_version" =~ .*rc.* ]]
+          elif [ -z $version ] && [ ${{ inputs.prerelease }} != 'true' ] && [[ "$old_version" =~ (alpha|beta|rc) ]]
           then
-            echo "Create final version from rc"
+            echo "Create final version from pre-release"
             version=$(semverup --bump-version patch)
             echo "forced_version=true" >> $GITHUB_OUTPUT
           else
@@ -193,7 +198,7 @@ jobs:
           version=${{ steps.version.outputs.version }}
           eof="EOF$(date +%s)"
           release_file="releases/$version.md"
-          if [ ${{ inputs.release_candidate }} == 'true' ]
+          if [ ${{ inputs.prerelease }} == 'true' ]
           then
             newsArg=''
             rcArg='--pre-release'
@@ -213,8 +218,8 @@ jobs:
             
             * Update Poetry's package dependencies
           EOF
-            # Update NEWS file if it is not a release candidate
-            if [ ${{ inputs.release_candidate }} != 'true' ]
+            # Update NEWS file if it is not a pre-release
+            if [ ${{ inputs.prerelease }} != 'true' ]
             then
               mv NEWS old_NEWS
               echo -e "# Releases\n" >> NEWS
@@ -241,7 +246,7 @@ jobs:
         name: Publish new version.
         if: steps.semverup.outcome == 'success'
         run: |
-          if [ ${{ inputs.release_candidate }} == 'true' ]
+          if [ ${{ inputs.prerelease }} == 'true' ]
           then
             publish ${{ steps.version.outputs.version }} "${{ inputs.git_name }} <${{ inputs.git_email }}>" --push origin --remote-branch main --no-cleanup
           else

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,7 @@ jobs:
     - name: Install dependencies
       run: |
         poetry install --with tests -vvv
+        poetry run pip install -r requirements_dev.txt
     - name: Tests
       run: |
         cd tests && poetry run pytest

--- a/.gitmodules
+++ b/.gitmodules
@@ -20,8 +20,8 @@
 	path = src/grimoirelab-toolkit
 	url = https://github.com/chaoss/grimoirelab-toolkit.git
 [submodule "src/grimoirelab-chronicler"]
-    path = src/grimoirelab-chronicler
-    url = https://github.com/grimoirelab/grimoirelab-chronicler.git
+	path = src/grimoirelab-chronicler
+	url = https://github.com/grimoirelab/grimoirelab-chronicler.git
 [submodule "src/grimoirelab-core"]
-    path = src/grimoirelab-core
-    url = https://github.com/grimoirelab/grimoirelab-core.git
+	path = src/grimoirelab-core
+	url = https://github.com/grimoirelab/grimoirelab-core.git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,9 +5,11 @@ FROM python:3.12-slim-bullseye
 
 LABEL maintainer="Santiago Dueñas <sduenas@bitergia.com>"
 
+ARG GRIMOIRELAB_RELEASE="2.x"
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEPLOY_USER=grimoirelab
-ENV GRIMOIRELAB_RELEASE="2.x"
+ENV GRIMOIRELAB_RELEASE=${GRIMOIRELAB_RELEASE}
 
 # Create a user and a group
 RUN groupadd -r $DEPLOY_USER && useradd -r -m -g $DEPLOY_USER $DEPLOY_USER

--- a/poetry.lock
+++ b/poetry.lock
@@ -589,14 +589,14 @@ packaging = "*"
 
 [[package]]
 name = "django"
-version = "5.2.7"
+version = "5.2.8"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "django-5.2.7-py3-none-any.whl", hash = "sha256:59a13a6515f787dec9d97a0438cd2efac78c8aca1c80025244b0fe507fe0754b"},
-    {file = "django-5.2.7.tar.gz", hash = "sha256:e0f6f12e2551b1716a95a63a1366ca91bbcd7be059862c1b18f989b1da356cdd"},
+    {file = "django-5.2.8-py3-none-any.whl", hash = "sha256:37e687f7bd73ddf043e2b6b97cfe02fcbb11f2dbb3adccc6a2b18c6daa054d7f"},
+    {file = "django-5.2.8.tar.gz", hash = "sha256:23254866a5bb9a2cfa6004e8b809ec6246eba4b58a7589bc2772f1bcc8456c7f"},
 ]
 
 [package.dependencies]
@@ -647,21 +647,6 @@ doc = ["sphinx"]
 test = ["black", "codecov", "cryptography", "flake8", "isort", "pytest", "pytest-cov", "pytest-django"]
 
 [[package]]
-name = "django-ipware"
-version = "7.0.1"
-description = "A Django application to retrieve user's IP address"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "django-ipware-7.0.1.tar.gz", hash = "sha256:d9ec43d2bf7cdf216fed8d494a084deb5761a54860a53b2e74346a4f384cff47"},
-    {file = "django_ipware-7.0.1-py2.py3-none-any.whl", hash = "sha256:db16bbee920f661ae7f678e4270460c85850f03c6761a4eaeb489bdc91f64709"},
-]
-
-[package.dependencies]
-python-ipware = ">=2.0.3"
-
-[[package]]
 name = "django-rq"
 version = "3.1"
 description = "An app that provides django integration for RQ (Redis Queue)"
@@ -706,28 +691,6 @@ google = ["google-cloud-storage (>=1.36.1)"]
 libcloud = ["apache-libcloud"]
 s3 = ["boto3 (>=1.4.4)"]
 sftp = ["paramiko (>=1.15)"]
-
-[[package]]
-name = "django-structlog"
-version = "9.1.1"
-description = "Structured Logging for Django"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "django_structlog-9.1.1-py3-none-any.whl", hash = "sha256:5b6ac3abdf6549e94ccb35160b1f10266f1627c3ac77844571235a08a1ddae66"},
-    {file = "django_structlog-9.1.1.tar.gz", hash = "sha256:14342c6c824581f1e063c88a8bc52314cd67995a3bd4a4fc8c27ea37ccd78947"},
-]
-
-[package.dependencies]
-asgiref = ">=3.6.0"
-django = ">=4.2"
-django-ipware = ">=6.0.2"
-structlog = ">=21.4.0"
-
-[package.extras]
-celery = ["celery (>=5.1)"]
-commands = ["django-extensions (>=1.4.9)"]
 
 [[package]]
 name = "django-treebeard"
@@ -971,14 +934,14 @@ grpcio-gcp = ["grpcio-gcp (>=0.2.2,<1.0.0)"]
 
 [[package]]
 name = "google-auth"
-version = "2.42.1"
+version = "2.43.0"
 description = "Google Authentication Library"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "google_auth-2.42.1-py2.py3-none-any.whl", hash = "sha256:eb73d71c91fc95dbd221a2eb87477c278a355e7367a35c0d84e6b0e5f9b4ad11"},
-    {file = "google_auth-2.42.1.tar.gz", hash = "sha256:30178b7a21aa50bffbdc1ffcb34ff770a2f65c712170ecd5446c4bef4dc2b94e"},
+    {file = "google_auth-2.43.0-py2.py3-none-any.whl", hash = "sha256:af628ba6fa493f75c7e9dbe9373d148ca9f4399b5ea29976519e0a3848eddd16"},
+    {file = "google_auth-2.43.0.tar.gz", hash = "sha256:88228eee5fc21b62a1b5fe773ca15e67778cb07dc8363adcb4a8827b52d81483"},
 ]
 
 [package.dependencies]
@@ -1017,18 +980,18 @@ grpc = ["grpcio (>=1.38.0,<2.0.0) ; python_version < \"3.14\"", "grpcio (>=1.75.
 
 [[package]]
 name = "google-cloud-storage"
-version = "3.4.1"
+version = "3.5.0"
 description = "Google Cloud Storage API client library"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "google_cloud_storage-3.4.1-py3-none-any.whl", hash = "sha256:972764cc0392aa097be8f49a5354e22eb47c3f62370067fb1571ffff4a1c1189"},
-    {file = "google_cloud_storage-3.4.1.tar.gz", hash = "sha256:6f041a297e23a4b485fad8c305a7a6e6831855c208bcbe74d00332a909f82268"},
+    {file = "google_cloud_storage-3.5.0-py3-none-any.whl", hash = "sha256:e28fd6ad8764e60dbb9a398a7bc3296e7920c494bc329057d828127e5f9630d3"},
+    {file = "google_cloud_storage-3.5.0.tar.gz", hash = "sha256:10b89e1d1693114b3e0ca921bdd28c5418701fd092e39081bb77e5cee0851ab7"},
 ]
 
 [package.dependencies]
-google-api-core = ">=2.15.0,<3.0.0"
+google-api-core = ">=2.27.0,<3.0.0"
 google-auth = ">=2.26.1,<3.0.0"
 google-cloud-core = ">=2.4.2,<3.0.0"
 google-crc32c = ">=1.1.3,<2.0.0"
@@ -1107,14 +1070,14 @@ requests = ["requests (>=2.18.0,<3.0.0dev)"]
 
 [[package]]
 name = "googleapis-common-protos"
-version = "1.71.0"
+version = "1.72.0"
 description = "Common protobufs used in Google APIs"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "googleapis_common_protos-1.71.0-py3-none-any.whl", hash = "sha256:59034a1d849dc4d18971997a72ac56246570afdd17f9369a0ff68218d50ab78c"},
-    {file = "googleapis_common_protos-1.71.0.tar.gz", hash = "sha256:1aec01e574e29da63c80ba9f7bbf1ccfaacf1da877f23609fe236ca7c72a2e2e"},
+    {file = "googleapis_common_protos-1.72.0-py3-none-any.whl", hash = "sha256:4299c5a82d5ae1a9702ada957347726b167f9f8d1fc352477702a1e851ff4038"},
+    {file = "googleapis_common_protos-1.72.0.tar.gz", hash = "sha256:e55a601c1b32b52d7a3e65f43563e2aa61bcd737998ee672ac9b951cd49319f5"},
 ]
 
 [package.dependencies]
@@ -1271,56 +1234,46 @@ name = "grimoirelab-chronicler"
 version = "0.1.0"
 description = "Generator of GrimoireLab events using Perceval data."
 optional = false
-python-versions = "^3.11"
+python-versions = "<4.0,>=3.11"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "grimoirelab_chronicler-0.1.0-py3-none-any.whl", hash = "sha256:baf222c2487f03e981b09815ea97f3fb71b84c608d28a317b476ba07c4e7b051"},
+    {file = "grimoirelab_chronicler-0.1.0.tar.gz", hash = "sha256:026bb4d4b459caaac7429fe5e0bd6bea9cac1a781fa813eabafc5ae5b1bf7be1"},
+]
 
 [package.dependencies]
-click = "^8.1.7"
-cloudevents = "^1.10.1"
-coverage = "^7.2.3"
+click = ">=8.1.7,<9.0.0"
+cloudevents = ">=1.10.1,<2.0.0"
+coverage = ">=7.2.3,<8.0.0"
 grimoirelab-toolkit = ">=0.3"
-
-[package.source]
-type = "git"
-url = "https://github.com/chaoss/grimoirelab-chronicler.git"
-reference = "HEAD"
-resolved_reference = "9e9288388c32cb5526a6a437a485ddf0b7bc4dff"
 
 [[package]]
 name = "grimoirelab-core"
 version = "0.1.0"
 description = "Core of GrimoireLab"
 optional = false
-python-versions = "^3.11"
+python-versions = "<4.0,>=3.11"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "grimoirelab_core-0.1.0-py3-none-any.whl", hash = "sha256:f980564af0dde7e7301b874f8a8974242e594d9954fdae206bbfcfeedad33125"},
+    {file = "grimoirelab_core-0.1.0.tar.gz", hash = "sha256:d0aed132e0f28f084cf9374d663deb3797dd89de4a7902ffdf48e849c8baacbe"},
+]
 
 [package.dependencies]
-django = "^5.2"
-django-cors-headers = "^4.6.0"
-django-rq = "^3.1"
-django-storages = {version = "^1.14.6", extras = ["google"]}
-django-structlog = "^9.0.1"
-djangorestframework = "^3.15.2"
-djangorestframework-simplejwt = "^5.4.0"
-drf-spectacular = "^0.28.0"
+django = ">=5.2,<6.0"
+django-cors-headers = ">=4.6.0,<5.0.0"
+django-rq = ">=3.1,<4.0"
+django-storages = {version = ">=1.14.6,<2.0.0", extras = ["google"]}
+djangorestframework = ">=3.15.2,<4.0.0"
+djangorestframework-simplejwt = ">=5.4.0,<6.0.0"
+drf-spectacular = ">=0.28.0,<0.29.0"
 grimoirelab-chronicler = ">=0.0.1rc2"
 grimoirelab-toolkit = ">=1.2.0"
-mysqlclient = "^2.0.3"
-opensearch-py = "^3.0.0"
+mysqlclient = ">=2.0.3,<3.0.0"
+opensearch-py = ">=3.0.0,<4.0.0"
 perceval = ">=1.3.4"
 sortinghat = ">=1.11.0"
-structlog = "^25.2.0"
-uWSGI = "^2.0"
-
-[package.source]
-type = "git"
-url = "https://github.com/chaoss/grimoirelab-core.git"
-reference = "HEAD"
-resolved_reference = "48f347e6bd50c3b3c0a34936685597141c09b95b"
+uWSGI = ">=2.0,<3.0"
 
 [[package]]
 name = "grimoirelab-toolkit"
@@ -2175,21 +2128,6 @@ files = [
 cli = ["click (>=5.0)"]
 
 [[package]]
-name = "python-ipware"
-version = "3.0.0"
-description = "A Python package to retrieve user's IP address"
-optional = false
-python-versions = ">=3.7"
-groups = ["main"]
-files = [
-    {file = "python_ipware-3.0.0-py3-none-any.whl", hash = "sha256:fc936e6e7ec9fcc107f9315df40658f468ac72f739482a707181742882e36b60"},
-    {file = "python_ipware-3.0.0.tar.gz", hash = "sha256:9117b1c4dddcb5d5ca49e6a9617de2fc66aec2ef35394563ac4eecabdf58c062"},
-]
-
-[package.extras]
-dev = ["coverage[toml]", "coveralls (>=3.3,<4.0)", "ruff", "twine"]
-
-[[package]]
 name = "pytz"
 version = "2025.2"
 description = "World timezone definitions, modern and historical"
@@ -2686,18 +2624,6 @@ dev = ["build", "hatch"]
 doc = ["sphinx"]
 
 [[package]]
-name = "structlog"
-version = "25.5.0"
-description = "Structured Logging for Python"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f"},
-    {file = "structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98"},
-]
-
-[[package]]
 name = "testcontainers"
 version = "4.13.2"
 description = "Python library for throwaway instances of anything that can run in a Docker container"
@@ -2836,119 +2762,119 @@ files = [
 
 [[package]]
 name = "wrapt"
-version = "2.0.0"
+version = "2.0.1"
 description = "Module for decorators, wrappers and monkey patching."
 optional = false
 python-versions = ">=3.8"
 groups = ["tests"]
 files = [
-    {file = "wrapt-2.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a7cebcee61f21b1e46aa32db8d9d93826d0fbf1ad85defc2ccfb93b4adef1435"},
-    {file = "wrapt-2.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:827e6e3a3a560f6ec1f5ee92d4319c21a0549384f896ec692f3201eda31ebd11"},
-    {file = "wrapt-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1a91075a5383a7cbfe46aed1845ef7c3f027e8e20e7d9a8a75e36ebc9b0dd15e"},
-    {file = "wrapt-2.0.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b6a18c813196e18146b8d041e20875bdb0cb09b94ac1d1e1146e0fa87b2deb0d"},
-    {file = "wrapt-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ec5028d26011a53c76bd91bb6198b30b438c6e0f7adb45f2ad84fe2655b6a104"},
-    {file = "wrapt-2.0.0-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bed9b04900204721a24bcefc652ca267b01c1e8ad8bc8c0cff81558a45a3aadc"},
-    {file = "wrapt-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:03442f2b45fa3f2b98a94a1917f52fb34670de8f96c0a009c02dbd512d855a3d"},
-    {file = "wrapt-2.0.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:17d0b5c42495ba142a1cee52b76414f9210591c84aae94dffda70240753bfb3c"},
-    {file = "wrapt-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ee44215e7d13e112a8fc74e12ed1a1f41cab2bc07b11cc703f2398cd114b261c"},
-    {file = "wrapt-2.0.0-cp310-cp310-win32.whl", hash = "sha256:fe6eafac3bc3c957ab6597a0c0654a0a308868458d00d218743e5b5fae51951c"},
-    {file = "wrapt-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:9e070c3491397fba0445b8977900271eca9656570cca7c900d9b9352186703a0"},
-    {file = "wrapt-2.0.0-cp310-cp310-win_arm64.whl", hash = "sha256:806e2e73186eb5e3546f39fb5d0405040e0088db0fc8b2f667fd1863de2b3c99"},
-    {file = "wrapt-2.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b7e221abb6c5387819db9323dac3c875b459695057449634f1111955d753c621"},
-    {file = "wrapt-2.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1147a84c8fc852426580af8b6e33138461ddbc65aa459a25ea539374d32069fa"},
-    {file = "wrapt-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5d6691d4a711504a0bc10de789842ad6ac627bed22937b10f37a1211a8ab7bb3"},
-    {file = "wrapt-2.0.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f460e1eb8e75a17c3918c8e35ba57625721eef2439ef0bcf05304ac278a65e1d"},
-    {file = "wrapt-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12c37784b77bf043bf65cc96c7195a5db474b8e54173208af076bdbb61df7b3e"},
-    {file = "wrapt-2.0.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:75e5c049eb583835f7a0e0e311d9dde9bfbaac723a6dd89d052540f9b2809977"},
-    {file = "wrapt-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e50bcbd5b65dac21b82319fcf18486e6ac439947e9305034b00704eb7405f553"},
-    {file = "wrapt-2.0.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:06b78cb6b9320f57737a52fede882640d93cface98332d1a3df0c5696ec9ae9f"},
-    {file = "wrapt-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8c8349ebfc3cd98bc9105e0112dd8c8ac1f3c7cb5601f9d02248cae83a63f748"},
-    {file = "wrapt-2.0.0-cp311-cp311-win32.whl", hash = "sha256:028f19ec29e204fe725139d4a8b09f77ecfb64f8f02b7ab5ee822c85e330b68b"},
-    {file = "wrapt-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:c6961f05e58d919153ba311b397b7b904b907132b7b8344dde47865d4bb5ec89"},
-    {file = "wrapt-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:be7e316c2accd5a31dbcc230de19e2a846a325f8967fdea72704d00e38e6af06"},
-    {file = "wrapt-2.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:73c6f734aecb1a030d9a265c13a425897e1ea821b73249bb14471445467ca71c"},
-    {file = "wrapt-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b4a7f8023b8ce8a36370154733c747f8d65c8697cb977d8b6efeb89291fff23e"},
-    {file = "wrapt-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a1cb62f686c50e9dab5983c68f6c8e9cbf14a6007935e683662898a7d892fa69"},
-    {file = "wrapt-2.0.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:43dc0550ae15e33e6bb45a82a5e1b5495be2587fbaa996244b509921810ee49f"},
-    {file = "wrapt-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39c5b45b056d630545e40674d1f5e1b51864b3546f25ab6a4a331943de96262e"},
-    {file = "wrapt-2.0.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:804e88f824b76240a1b670330637ccfd2d18b9efa3bb4f02eb20b2f64880b324"},
-    {file = "wrapt-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c2c476aa3fc2b9899c3f7b20963fac4f952e7edb74a31fc92f7745389a2e3618"},
-    {file = "wrapt-2.0.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:8d851e526891216f89fcb7a1820dad9bd503ba3468fb9635ee28e93c781aa98e"},
-    {file = "wrapt-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b95733c2360c4a8656ee93c7af78e84c0bd617da04a236d7a456c8faa34e7a2d"},
-    {file = "wrapt-2.0.0-cp312-cp312-win32.whl", hash = "sha256:ea56817176834edf143df1109ae8fdaa087be82fdad3492648de0baa8ae82bf2"},
-    {file = "wrapt-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:3c7d3bee7be7a2665286103f4d1f15405c8074e6e1f89dac5774f9357c9a3809"},
-    {file = "wrapt-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:680f707e1d26acbc60926659799b15659f077df5897a6791c7c598a5d4a211c4"},
-    {file = "wrapt-2.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e2ea096db28d5eb64d381af0e93464621ace38a7003a364b6b5ffb7dd713aabe"},
-    {file = "wrapt-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c92b5a82d28491e3f14f037e1aae99a27a5e6e0bb161e65f52c0445a3fa7c940"},
-    {file = "wrapt-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:81d234718aabe632d179fac52c7f69f0f99fbaac4d4bcd670e62462bbcbfcad7"},
-    {file = "wrapt-2.0.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:db2eea83c43f84e4e41dbbb4c1de371a53166e55f900a6b130c3ef51c6345c1a"},
-    {file = "wrapt-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:65f50e356c425c061e1e17fe687ff30e294fed9bf3441dc1f13ef73859c2a817"},
-    {file = "wrapt-2.0.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:887f2a667e3cbfb19e204032d42ad7dedaa43972e4861dc7a3d51ae951d9b578"},
-    {file = "wrapt-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9054829da4be461e3ad3192e4b6bbf1fc18af64c9975ce613aec191924e004dc"},
-    {file = "wrapt-2.0.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b952ffd77133a5a2798ee3feb18e51b0a299d2f440961e5bb7737dbb02e57289"},
-    {file = "wrapt-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e25fde03c480061b8234d8ee4863eb5f40a9be4fb258ce105b364de38fc6bcf9"},
-    {file = "wrapt-2.0.0-cp313-cp313-win32.whl", hash = "sha256:49e982b7860d325094978292a49e0418833fc7fc42c0dc7cd0b7524d7d06ee74"},
-    {file = "wrapt-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:6e5c86389d9964050ce50babe247d172a5e3911d59a64023b90db2b4fa00ae7c"},
-    {file = "wrapt-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:b96fdaa4611e05c7231937930567d3c16782be9dbcf03eb9f60d83e57dd2f129"},
-    {file = "wrapt-2.0.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f2c7b7fead096dbf1dcc455b7f59facb05de3f5bfb04f60a69f98cdfe6049e5f"},
-    {file = "wrapt-2.0.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:04c7c8393f25b11c0faa5d907dd9eb462e87e4e7ba55e308a046d7ed37f4bbe2"},
-    {file = "wrapt-2.0.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a93e0f8b376c0735b2f4daf58018b4823614d2b896cb72b6641c4d3dbdca1d75"},
-    {file = "wrapt-2.0.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b42d13603da4416c43c430dbc6313c8d7ff745c40942f146ed4f6dd02c7d2547"},
-    {file = "wrapt-2.0.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8bbd2472abf8c33480ad2314b1f8fac45d592aba6cc093e8839a7b2045660e6"},
-    {file = "wrapt-2.0.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e64a3a1fd9a308ab9b815a2ad7a65b679730629dbf85f8fc3f7f970d634ee5df"},
-    {file = "wrapt-2.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d61214525eaf88e0d0edf3d1ad5b5889863c6f88e588c6cdc6aa4ee5d1f10a4a"},
-    {file = "wrapt-2.0.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:04f7a5f92c5f7324a1735043cc467b1295a1c5b4e0c1395472b7c44706e3dc61"},
-    {file = "wrapt-2.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2356f76cb99b3de5b4e5b8210367fbbb81c7309fe39b622f5d199dd88eb7f765"},
-    {file = "wrapt-2.0.0-cp313-cp313t-win32.whl", hash = "sha256:0a921b657a224e40e4bc161b5d33934583b34f0c9c5bdda4e6ac66f9d2fcb849"},
-    {file = "wrapt-2.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:c16f6d4eea98080f6659a8a7fc559d4a0a337ee66960659265cad2c8a40f7c0f"},
-    {file = "wrapt-2.0.0-cp313-cp313t-win_arm64.whl", hash = "sha256:52878edc13dc151c58a9966621d67163a80654bc6cff4b2e1c79fa62d0352b26"},
-    {file = "wrapt-2.0.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:79a53d86c2aff7b32cc77267e3a308365d1fcb881e74bc9cbe26f63ee90e37f0"},
-    {file = "wrapt-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:d731a4f22ed6ffa4cb551b4d2b0c24ff940c27a88edaf8e3490a5ee3a05aef71"},
-    {file = "wrapt-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3e02ab8c0ac766a5a6e81cd3b6cc39200c69051826243182175555872522bd5a"},
-    {file = "wrapt-2.0.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:895870602d65d7338edb3b6a717d856632ad9f14f7ff566214e4fb11f0816649"},
-    {file = "wrapt-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b9ad4fab76a0086dc364c4f17f39ad289600e73ef5c6e9ab529aff22cac1ac3"},
-    {file = "wrapt-2.0.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e7ca0562606d7bad2736b2c18f61295d61f50cd3f4bfc51753df13614dbcce1b"},
-    {file = "wrapt-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fe089d9f5a4a3dea0108a8ae34bced114d0c4cca417bada1c5e8f42d98af9050"},
-    {file = "wrapt-2.0.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e761f2d2f8dbc80384af3d547b522a80e67db3e319c7b02e7fd97aded0a8a678"},
-    {file = "wrapt-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:17ba1bdc52d0c783481850996aa26cea5237720769197335abea2ae6b4c23bc0"},
-    {file = "wrapt-2.0.0-cp314-cp314-win32.whl", hash = "sha256:f73318741b141223a4674ba96992aa2291b1b3f7a5e85cb3c2c964f86171eb45"},
-    {file = "wrapt-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:8e08d4edb13cafe7b3260f31d4de033f73d3205774540cf583bffaa4bec97db9"},
-    {file = "wrapt-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:af01695c2b7bbd8d67b869d8e3de2b123a7bfbee0185bdd138c2775f75373b83"},
-    {file = "wrapt-2.0.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:057f02c13cce7b26c79624c06a3e1c2353e6dc9708525232232f6768118042ca"},
-    {file = "wrapt-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:79bdd84570267f3f43d609c892ae2d30b91ee4b8614c2cbfd311a2965f1c9bdb"},
-    {file = "wrapt-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:93c8b4f4d54fd401a817abbfc9bf482aa72fd447f8adf19ce81d035b3f5c762c"},
-    {file = "wrapt-2.0.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5e09ffd31001dce71c2c2a4fc201bdba9a2f9f62b23700cf24af42266e784741"},
-    {file = "wrapt-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d87c285ff04e26083c4b03546e7b74df7ba4f1f32f1dcb92e9ac13c2dbb4c379"},
-    {file = "wrapt-2.0.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e52e50ea0a72ea48d1291cf8b8aaedcc99072d9dc5baba6b820486dcf4c67da8"},
-    {file = "wrapt-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fd4c95536975895f32571073446e614d5e2810b666b64955586dcddfd438fd3"},
-    {file = "wrapt-2.0.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:d6ebfe9283209220ed9de80a3e9442aab8fc2be5a9bbf8491b99e02ca9349a89"},
-    {file = "wrapt-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5d3ebd784804f146b7ea55359beb138e23cc18e5a5cc2cf26ad438723c00ce3a"},
-    {file = "wrapt-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:9b15940ae9debc8b40b15dc57e1ce4433f7fb9d3f8761c7fab1ddd94cb999d99"},
-    {file = "wrapt-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:7a0efbbc06d3e2077476a04f55859819d23206600b4c33f791359a8e6fa3c362"},
-    {file = "wrapt-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:7fec8a9455c029c8cf4ff143a53b6e7c463268d42be6c17efa847ebd2f809965"},
-    {file = "wrapt-2.0.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:ac3d8beac68e4863c703b844fcc82693f83f933b37d2a54e9d513b2aab9c76aa"},
-    {file = "wrapt-2.0.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f4b8f8644602803add6848c81b7d214cfd397b1ebab2130dc8530570d888155c"},
-    {file = "wrapt-2.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:93cb5bff1fcd89b75f869e4f69566a91ab2c9f13e8edf0241fd5777b2fa6d48e"},
-    {file = "wrapt-2.0.0-cp38-cp38-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e0eb6d155d02c7525b7ec09856cda5e611fc6eb9ab40d140e1f35f27ac7d5eae"},
-    {file = "wrapt-2.0.0-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:309dd467a94ee38a7aa5752bda64e660aeab5723b26200d0b65a375dad9add09"},
-    {file = "wrapt-2.0.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:a55e8edd08e2eece131d90d82cd1521962d9152829b22c56e68539526d605825"},
-    {file = "wrapt-2.0.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:1724dd7b84d419c80ba839da81ad78b02ac30df626e5aefcb18e94632a965f13"},
-    {file = "wrapt-2.0.0-cp38-cp38-win32.whl", hash = "sha256:f8255c380a79f6752d0b920e69a5d656d863675d9c433eeb5548518ee2c8d9da"},
-    {file = "wrapt-2.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:829c8d46465dbae49dba91516f11200a2b5ea91eae8afaccbc035f0b651eb9c4"},
-    {file = "wrapt-2.0.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:094d348ce7e6ce37bf6ed9a6ecc11886c96f447b3ffebc7539ca197daa9a997e"},
-    {file = "wrapt-2.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:98223acaa25b1449d993a3f4ffc8b5a03535e4041b37bf6a25459a0c74ee4cfc"},
-    {file = "wrapt-2.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2b79bf04c722035b1c474980dc1a64369feab7b703d6fe67da2d8664ed0bc980"},
-    {file = "wrapt-2.0.0-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:623242959cb0c53f76baeb929be79f5f6a9a1673ef51628072b91bf299af2212"},
-    {file = "wrapt-2.0.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:59dc94afc4542c7d9b9447fb2ae1168b5a29064eca4061dbbf3b3c26df268334"},
-    {file = "wrapt-2.0.0-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d7c532cc9f0a9e6017f8d3c37f478a3e3a5dffa955ebba556274e5e916c058f7"},
-    {file = "wrapt-2.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9d72c725cefbcc8ebab85c8352e5062ae87b6e323858e934e16b54ced580435a"},
-    {file = "wrapt-2.0.0-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:2ca35b83497276c2ca0b072d2c00da2edde4c2a6c8c650eafcd1a006c17ab231"},
-    {file = "wrapt-2.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2fc55d0da29318a5da33c2827aef8946bba046ac609a4784a90faff73c511174"},
-    {file = "wrapt-2.0.0-cp39-cp39-win32.whl", hash = "sha256:9c100b0598f3763274f2033bcc0454de7486409f85bc6da58b49e5971747eb36"},
-    {file = "wrapt-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:1316972a72c67936a07dbb48e2464356d91dd9674335aaec087b60094d87750b"},
-    {file = "wrapt-2.0.0-cp39-cp39-win_arm64.whl", hash = "sha256:5aad54ff45da9784573099696fd84841c7e559ce312f02afa6aa7e89b58e2c2f"},
-    {file = "wrapt-2.0.0-py3-none-any.whl", hash = "sha256:02482fb0df89857e35427dfb844319417e14fae05878f295ee43fa3bf3b15502"},
-    {file = "wrapt-2.0.0.tar.gz", hash = "sha256:35a542cc7a962331d0279735c30995b024e852cf40481e384fd63caaa391cbb9"},
+    {file = "wrapt-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:64b103acdaa53b7caf409e8d45d39a8442fe6dcfec6ba3f3d141e0cc2b5b4dbd"},
+    {file = "wrapt-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:91bcc576260a274b169c3098e9a3519fb01f2989f6d3d386ef9cbf8653de1374"},
+    {file = "wrapt-2.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ab594f346517010050126fcd822697b25a7031d815bb4fbc238ccbe568216489"},
+    {file = "wrapt-2.0.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:36982b26f190f4d737f04a492a68accbfc6fa042c3f42326fdfbb6c5b7a20a31"},
+    {file = "wrapt-2.0.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23097ed8bc4c93b7bf36fa2113c6c733c976316ce0ee2c816f64ca06102034ef"},
+    {file = "wrapt-2.0.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8bacfe6e001749a3b64db47bcf0341da757c95959f592823a93931a422395013"},
+    {file = "wrapt-2.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8ec3303e8a81932171f455f792f8df500fc1a09f20069e5c16bd7049ab4e8e38"},
+    {file = "wrapt-2.0.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:3f373a4ab5dbc528a94334f9fe444395b23c2f5332adab9ff4ea82f5a9e33bc1"},
+    {file = "wrapt-2.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f49027b0b9503bf6c8cdc297ca55006b80c2f5dd36cecc72c6835ab6e10e8a25"},
+    {file = "wrapt-2.0.1-cp310-cp310-win32.whl", hash = "sha256:8330b42d769965e96e01fa14034b28a2a7600fbf7e8f0cc90ebb36d492c993e4"},
+    {file = "wrapt-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:1218573502a8235bb8a7ecaed12736213b22dcde9feab115fa2989d42b5ded45"},
+    {file = "wrapt-2.0.1-cp310-cp310-win_arm64.whl", hash = "sha256:eda8e4ecd662d48c28bb86be9e837c13e45c58b8300e43ba3c9b4fa9900302f7"},
+    {file = "wrapt-2.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0e17283f533a0d24d6e5429a7d11f250a58d28b4ae5186f8f47853e3e70d2590"},
+    {file = "wrapt-2.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:85df8d92158cb8f3965aecc27cf821461bb5f40b450b03facc5d9f0d4d6ddec6"},
+    {file = "wrapt-2.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c1be685ac7700c966b8610ccc63c3187a72e33cab53526a27b2a285a662cd4f7"},
+    {file = "wrapt-2.0.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:df0b6d3b95932809c5b3fecc18fda0f1e07452d05e2662a0b35548985f256e28"},
+    {file = "wrapt-2.0.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4da7384b0e5d4cae05c97cd6f94faaf78cc8b0f791fc63af43436d98c4ab37bb"},
+    {file = "wrapt-2.0.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ec65a78fbd9d6f083a15d7613b2800d5663dbb6bb96003899c834beaa68b242c"},
+    {file = "wrapt-2.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7de3cc939be0e1174969f943f3b44e0d79b6f9a82198133a5b7fc6cc92882f16"},
+    {file = "wrapt-2.0.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:fb1a5b72cbd751813adc02ef01ada0b0d05d3dcbc32976ce189a1279d80ad4a2"},
+    {file = "wrapt-2.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3fa272ca34332581e00bf7773e993d4f632594eb2d1b0b162a9038df0fd971dd"},
+    {file = "wrapt-2.0.1-cp311-cp311-win32.whl", hash = "sha256:fc007fdf480c77301ab1afdbb6ab22a5deee8885f3b1ed7afcb7e5e84a0e27be"},
+    {file = "wrapt-2.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:47434236c396d04875180171ee1f3815ca1eada05e24a1ee99546320d54d1d1b"},
+    {file = "wrapt-2.0.1-cp311-cp311-win_arm64.whl", hash = "sha256:837e31620e06b16030b1d126ed78e9383815cbac914693f54926d816d35d8edf"},
+    {file = "wrapt-2.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1fdbb34da15450f2b1d735a0e969c24bdb8d8924892380126e2a293d9902078c"},
+    {file = "wrapt-2.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3d32794fe940b7000f0519904e247f902f0149edbe6316c710a8562fb6738841"},
+    {file = "wrapt-2.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:386fb54d9cd903ee0012c09291336469eb7b244f7183d40dc3e86a16a4bace62"},
+    {file = "wrapt-2.0.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7b219cb2182f230676308cdcacd428fa837987b89e4b7c5c9025088b8a6c9faf"},
+    {file = "wrapt-2.0.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:641e94e789b5f6b4822bb8d8ebbdfc10f4e4eae7756d648b717d980f657a9eb9"},
+    {file = "wrapt-2.0.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fe21b118b9f58859b5ebaa4b130dee18669df4bd111daad082b7beb8799ad16b"},
+    {file = "wrapt-2.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:17fb85fa4abc26a5184d93b3efd2dcc14deb4b09edcdb3535a536ad34f0b4dba"},
+    {file = "wrapt-2.0.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:b89ef9223d665ab255ae42cc282d27d69704d94be0deffc8b9d919179a609684"},
+    {file = "wrapt-2.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a453257f19c31b31ba593c30d997d6e5be39e3b5ad9148c2af5a7314061c63eb"},
+    {file = "wrapt-2.0.1-cp312-cp312-win32.whl", hash = "sha256:3e271346f01e9c8b1130a6a3b0e11908049fe5be2d365a5f402778049147e7e9"},
+    {file = "wrapt-2.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:2da620b31a90cdefa9cd0c2b661882329e2e19d1d7b9b920189956b76c564d75"},
+    {file = "wrapt-2.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:aea9c7224c302bc8bfc892b908537f56c430802560e827b75ecbde81b604598b"},
+    {file = "wrapt-2.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:47b0f8bafe90f7736151f61482c583c86b0693d80f075a58701dd1549b0010a9"},
+    {file = "wrapt-2.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:cbeb0971e13b4bd81d34169ed57a6dda017328d1a22b62fda45e1d21dd06148f"},
+    {file = "wrapt-2.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb7cffe572ad0a141a7886a1d2efa5bef0bf7fe021deeea76b3ab334d2c38218"},
+    {file = "wrapt-2.0.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c8d60527d1ecfc131426b10d93ab5d53e08a09c5fa0175f6b21b3252080c70a9"},
+    {file = "wrapt-2.0.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c654eafb01afac55246053d67a4b9a984a3567c3808bb7df2f8de1c1caba2e1c"},
+    {file = "wrapt-2.0.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:98d873ed6c8b4ee2418f7afce666751854d6d03e3c0ec2a399bb039cd2ae89db"},
+    {file = "wrapt-2.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c9e850f5b7fc67af856ff054c71690d54fa940c3ef74209ad9f935b4f66a0233"},
+    {file = "wrapt-2.0.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e505629359cb5f751e16e30cf3f91a1d3ddb4552480c205947da415d597f7ac2"},
+    {file = "wrapt-2.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2879af909312d0baf35f08edeea918ee3af7ab57c37fe47cb6a373c9f2749c7b"},
+    {file = "wrapt-2.0.1-cp313-cp313-win32.whl", hash = "sha256:d67956c676be5a24102c7407a71f4126d30de2a569a1c7871c9f3cabc94225d7"},
+    {file = "wrapt-2.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:9ca66b38dd642bf90c59b6738af8070747b610115a39af2498535f62b5cdc1c3"},
+    {file = "wrapt-2.0.1-cp313-cp313-win_arm64.whl", hash = "sha256:5a4939eae35db6b6cec8e7aa0e833dcca0acad8231672c26c2a9ab7a0f8ac9c8"},
+    {file = "wrapt-2.0.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a52f93d95c8d38fed0669da2ebdb0b0376e895d84596a976c15a9eb45e3eccb3"},
+    {file = "wrapt-2.0.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4e54bbf554ee29fcceee24fa41c4d091398b911da6e7f5d7bffda963c9aed2e1"},
+    {file = "wrapt-2.0.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:908f8c6c71557f4deaa280f55d0728c3bca0960e8c3dd5ceeeafb3c19942719d"},
+    {file = "wrapt-2.0.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e2f84e9af2060e3904a32cea9bb6db23ce3f91cfd90c6b426757cf7cc01c45c7"},
+    {file = "wrapt-2.0.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e3612dc06b436968dfb9142c62e5dfa9eb5924f91120b3c8ff501ad878f90eb3"},
+    {file = "wrapt-2.0.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6d2d947d266d99a1477cd005b23cbd09465276e302515e122df56bb9511aca1b"},
+    {file = "wrapt-2.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:7d539241e87b650cbc4c3ac9f32c8d1ac8a54e510f6dca3f6ab60dcfd48c9b10"},
+    {file = "wrapt-2.0.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:4811e15d88ee62dbf5c77f2c3ff3932b1e3ac92323ba3912f51fc4016ce81ecf"},
+    {file = "wrapt-2.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c1c91405fcf1d501fa5d55df21e58ea49e6b879ae829f1039faaf7e5e509b41e"},
+    {file = "wrapt-2.0.1-cp313-cp313t-win32.whl", hash = "sha256:e76e3f91f864e89db8b8d2a8311d57df93f01ad6bb1e9b9976d1f2e83e18315c"},
+    {file = "wrapt-2.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:83ce30937f0ba0d28818807b303a412440c4b63e39d3d8fc036a94764b728c92"},
+    {file = "wrapt-2.0.1-cp313-cp313t-win_arm64.whl", hash = "sha256:4b55cacc57e1dc2d0991dbe74c6419ffd415fb66474a02335cb10efd1aa3f84f"},
+    {file = "wrapt-2.0.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:5e53b428f65ece6d9dad23cb87e64506392b720a0b45076c05354d27a13351a1"},
+    {file = "wrapt-2.0.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:ad3ee9d0f254851c71780966eb417ef8e72117155cff04821ab9b60549694a55"},
+    {file = "wrapt-2.0.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7b822c61ed04ee6ad64bc90d13368ad6eb094db54883b5dde2182f67a7f22c0"},
+    {file = "wrapt-2.0.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7164a55f5e83a9a0b031d3ffab4d4e36bbec42e7025db560f225489fa929e509"},
+    {file = "wrapt-2.0.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e60690ba71a57424c8d9ff28f8d006b7ad7772c22a4af432188572cd7fa004a1"},
+    {file = "wrapt-2.0.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3cd1a4bd9a7a619922a8557e1318232e7269b5fb69d4ba97b04d20450a6bf970"},
+    {file = "wrapt-2.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b4c2e3d777e38e913b8ce3a6257af72fb608f86a1df471cb1d4339755d0a807c"},
+    {file = "wrapt-2.0.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3d366aa598d69416b5afedf1faa539fac40c1d80a42f6b236c88c73a3c8f2d41"},
+    {file = "wrapt-2.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c235095d6d090aa903f1db61f892fffb779c1eaeb2a50e566b52001f7a0f66ed"},
+    {file = "wrapt-2.0.1-cp314-cp314-win32.whl", hash = "sha256:bfb5539005259f8127ea9c885bdc231978c06b7a980e63a8a61c8c4c979719d0"},
+    {file = "wrapt-2.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:4ae879acc449caa9ed43fc36ba08392b9412ee67941748d31d94e3cedb36628c"},
+    {file = "wrapt-2.0.1-cp314-cp314-win_arm64.whl", hash = "sha256:8639b843c9efd84675f1e100ed9e99538ebea7297b62c4b45a7042edb84db03e"},
+    {file = "wrapt-2.0.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:9219a1d946a9b32bb23ccae66bdb61e35c62773ce7ca6509ceea70f344656b7b"},
+    {file = "wrapt-2.0.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:fa4184e74197af3adad3c889a1af95b53bb0466bced92ea99a0c014e48323eec"},
+    {file = "wrapt-2.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c5ef2f2b8a53b7caee2f797ef166a390fef73979b15778a4a153e4b5fedce8fa"},
+    {file = "wrapt-2.0.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e042d653a4745be832d5aa190ff80ee4f02c34b21f4b785745eceacd0907b815"},
+    {file = "wrapt-2.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2afa23318136709c4b23d87d543b425c399887b4057936cd20386d5b1422b6fa"},
+    {file = "wrapt-2.0.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6c72328f668cf4c503ffcf9434c2b71fdd624345ced7941bc6693e61bbe36bef"},
+    {file = "wrapt-2.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3793ac154afb0e5b45d1233cb94d354ef7a983708cc3bb12563853b1d8d53747"},
+    {file = "wrapt-2.0.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:fec0d993ecba3991645b4857837277469c8cc4c554a7e24d064d1ca291cfb81f"},
+    {file = "wrapt-2.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:949520bccc1fa227274da7d03bf238be15389cd94e32e4297b92337df9b7a349"},
+    {file = "wrapt-2.0.1-cp314-cp314t-win32.whl", hash = "sha256:be9e84e91d6497ba62594158d3d31ec0486c60055c49179edc51ee43d095f79c"},
+    {file = "wrapt-2.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:61c4956171c7434634401db448371277d07032a81cc21c599c22953374781395"},
+    {file = "wrapt-2.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:35cdbd478607036fee40273be8ed54a451f5f23121bd9d4be515158f9498f7ad"},
+    {file = "wrapt-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:90897ea1cf0679763b62e79657958cd54eae5659f6360fc7d2ccc6f906342183"},
+    {file = "wrapt-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:50844efc8cdf63b2d90cd3d62d4947a28311e6266ce5235a219d21b195b4ec2c"},
+    {file = "wrapt-2.0.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:49989061a9977a8cbd6d20f2efa813f24bf657c6990a42967019ce779a878dbf"},
+    {file = "wrapt-2.0.1-cp38-cp38-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:09c7476ab884b74dce081ad9bfd07fe5822d8600abade571cb1f66d5fc915af6"},
+    {file = "wrapt-2.0.1-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1a8a09a004ef100e614beec82862d11fc17d601092c3599afd22b1f36e4137e"},
+    {file = "wrapt-2.0.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:89a82053b193837bf93c0f8a57ded6e4b6d88033a499dadff5067e912c2a41e9"},
+    {file = "wrapt-2.0.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:f26f8e2ca19564e2e1fdbb6a0e47f36e0efbab1acc31e15471fad88f828c75f6"},
+    {file = "wrapt-2.0.1-cp38-cp38-win32.whl", hash = "sha256:115cae4beed3542e37866469a8a1f2b9ec549b4463572b000611e9946b86e6f6"},
+    {file = "wrapt-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:c4012a2bd37059d04f8209916aa771dfb564cccb86079072bdcd48a308b6a5c5"},
+    {file = "wrapt-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:68424221a2dc00d634b54f92441914929c5ffb1c30b3b837343978343a3512a3"},
+    {file = "wrapt-2.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6bd1a18f5a797fe740cb3d7a0e853a8ce6461cc62023b630caec80171a6b8097"},
+    {file = "wrapt-2.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fb3a86e703868561c5cad155a15c36c716e1ab513b7065bd2ac8ed353c503333"},
+    {file = "wrapt-2.0.1-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5dc1b852337c6792aa111ca8becff5bacf576bf4a0255b0f05eb749da6a1643e"},
+    {file = "wrapt-2.0.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c046781d422f0830de6329fa4b16796096f28a92c8aef3850674442cdcb87b7f"},
+    {file = "wrapt-2.0.1-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f73f9f7a0ebd0db139253d27e5fc8d2866ceaeef19c30ab5d69dcbe35e1a6981"},
+    {file = "wrapt-2.0.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:b667189cf8efe008f55bbda321890bef628a67ab4147ebf90d182f2dadc78790"},
+    {file = "wrapt-2.0.1-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:a9a83618c4f0757557c077ef71d708ddd9847ed66b7cc63416632af70d3e2308"},
+    {file = "wrapt-2.0.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:1e9b121e9aeb15df416c2c960b8255a49d44b4038016ee17af03975992d03931"},
+    {file = "wrapt-2.0.1-cp39-cp39-win32.whl", hash = "sha256:1f186e26ea0a55f809f232e92cc8556a0977e00183c3ebda039a807a42be1494"},
+    {file = "wrapt-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:bf4cb76f36be5de950ce13e22e7fdf462b35b04665a12b64f3ac5c1bbbcf3728"},
+    {file = "wrapt-2.0.1-cp39-cp39-win_arm64.whl", hash = "sha256:d6cc985b9c8b235bd933990cdbf0f891f8e010b65a3911f7a55179cd7b0fc57b"},
+    {file = "wrapt-2.0.1-py3-none-any.whl", hash = "sha256:4d2ce1bf1a48c5277d7969259232b57645aae5686dba1eaeade39442277afbca"},
+    {file = "wrapt-2.0.1.tar.gz", hash = "sha256:9c9c635e78497cacb81e84f8b11b23e0aacac7a136e73b8e5b2109a1d9fc468f"},
 ]
 
 [package.extras]
@@ -2957,4 +2883,4 @@ dev = ["pytest", "setuptools"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "0496838939644985be7c6daeee16071347f63279752353606cbb4b31c0bffb52"
+content-hash = "88237001090d096fcced7b4956864e2aa247357545dfbfc5fb8d174e29a7fc8b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,14 +36,14 @@ classifiers = [
 python = "^3.11"
 
 grimoirelab-toolkit = {version = ">=1.2.0", allow-prereleases = true}
-perceval-mozilla = {version = ">=1.0.11", allow-prereleases = true}
-perceval-opnfv = {version = ">=1.0.11", allow-prereleases = true}
-perceval-puppet = {version = ">=1.0.11", allow-prereleases = true}
-perceval-weblate = {version = ">=1.0.11", allow-prereleases = true}
-sortinghat = {version = ">=1.6.2", allow-prereleases = true}
-perceval = {version = ">=1.1.1", allow-prereleases = true}
-grimoirelab-chronicler = {git = "https://github.com/chaoss/grimoirelab-chronicler.git", allow-prereleases = true}
-grimoirelab-core = {git = "https://github.com/chaoss/grimoirelab-core.git", allow-prereleases = true}
+perceval-mozilla = {version = ">=1.2.1", allow-prereleases = true}
+perceval-opnfv = {version = ">=1.1.1", allow-prereleases = true}
+perceval-puppet = {version = ">=1.1.1", allow-prereleases = true}
+perceval-weblate = {version = ">=1.1.1", allow-prereleases = true}
+sortinghat = {version = ">=1.12.0", allow-prereleases = true}
+perceval = {version = ">=1.4.0", allow-prereleases = true}
+grimoirelab-chronicler = {version = ">=0.1.0", allow-prereleases = true}
+grimoirelab-core = {version = ">=0.1.0", allow-prereleases = true}
 
 [tool.poetry.group.tests]
 optional = true

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,5 @@
+-e git+https://github.com/chaoss/grimoirelab-toolkit.git/#egg=grimoirelab-toolkit
+-e git+https://github.com/chaoss/grimoirelab-perceval/#egg=perceval
+-e git+https://github.com/chaoss/grimoirelab-sortinghat/#egg=sortinghat
+-e git+https://github.com/chaoss/grimoirelab-chronicler.git/#egg=grimoirelab-chronicler
+-e git+https://github.com/chaoss/grimoirelab-core.git/#egg=grimoirelab-core


### PR DESCRIPTION
This updated workflow will generate alpha releases for` grimoirelab-core`, `grimoirelab-chronicler`, and `grimoirelab` 2.x.
Releases for other packages will not be created until the final release.

When this workflow is executed:
- From the 2.x branch
- With `Create a pre-release version` selected
- Using the `alpha` label
- With `Create a major version` selected

It will create:
- Version `1.0.0-alpha.1` for `grimoirelab-core` and `grimoirelab-chronicler`
- Version `2.0.0-alpha.1` for `grimoirelab`

For the final release, we need to update the workflow to include all the other components.

This PR depends on:
- https://github.com/chaoss/grimoirelab/pull/787 (To fix the performance tests)
- https://github.com/chaoss/grimoirelab/pull/783 (Uses the updated image and workflow from this PR)

Related to https://github.com/chaoss/grimoirelab/issues/807