### PR TITLE
Update version formatting for release candidates

### DIFF
--- a/.github/workflows/grimoirelab-release.yml
+++ b/.github/workflows/grimoirelab-release.yml
@@ -56,7 +56,7 @@ jobs:
           echo "bump_major=${{ inputs.bump_major }}" >> $GITHUB_OUTPUT
 
   grimoirelab-chronicler:
-    name: chronicler
+    name: GrimoireLab Chronicler
     needs:
       - variables-job
     uses: ./.github/workflows/release-grimoirelab-component.yml
@@ -131,7 +131,7 @@ jobs:
       - id: semverup
         name: Update version number
         env:
-          chronicler_version: "${{ needs.grimoirelab-chronicler.outputs.version}}"
+          grimoirelab_chronicler_version: "${{ needs.grimoirelab-chronicler.outputs.version}}"
           grimoirelab_core_version: "${{ needs.grimoirelab-core.outputs.version}}"
         run: |
           BUMP_MAJOR=4
@@ -143,9 +143,13 @@ jobs:
             old=$1
             old=${old%-*}
             old=${old%rc*}
+            old=${old%a*}
+            old=${old%b*}
             current=$2
             current=${current%-*}
             current=${current%rc*}
+            current=${current%a*}
+            current=${current%b*}
             
             currentArr=(${current//./ })
             oldArr=(${old//./ })
@@ -169,7 +173,7 @@ jobs:
             poetry show -l $pkg | grep version | head -1 | awk '{print $3}'
           }
           
-          pkgs=("chronicler"
+          pkgs=("grimoirelab-chronicler"
           "grimoirelab-core")
           
           if [ ${{ inputs.prerelease }} == 'true' ]
@@ -275,9 +279,9 @@ jobs:
       - name: Generate NEWS from packages
         if: steps.custom_notes.outputs.custom_notes == 'false'
         env:
-          notes_chronicler: "${{ needs.grimoirelab-chronicler.outputs.notes}}"
+          notes_grimoirelab_chronicler: "${{ needs.grimoirelab-chronicler.outputs.notes}}"
           notes_grimoirelab_core: "${{ needs.grimoirelab-core.outputs.notes}}"
-          version_chronicler: "${{ needs.grimoirelab-chronicler.outputs.version }}"
+          version_grimoirelab_chronicler: "${{ needs.grimoirelab-chronicler.outputs.version }}"
           version_grimoirelab_core: "${{ needs.grimoirelab-core.outputs.version }}"
         run: |
           version=${{ steps.semverup.outputs.version }}
@@ -287,7 +291,7 @@ jobs:
           today=$(date -u "+%Y-%m-%d")
           
           packages=(
-          chronicler
+          grimoirelab_chronicler
           grimoirelab_core
           )
           

--- a/.github/workflows/release-grimoirelab-component.yml
+++ b/.github/workflows/release-grimoirelab-component.yml
@@ -294,10 +294,14 @@ jobs:
         run: |
           package="${{ inputs.module_name }}"
           version="${{ steps.version.outputs.version }}"
-          # Format version 1.2.3-rc.1 to 1.2.3rc1
+          # Format rc version 1.2.3-rc.1 to 1.2.3rc1
+          # Format alpha version 1.2.3-alpha.1 to 1.2.3a1
+          # Format beta version 1.2.3-beta.1 to 1.2.3b1
           versionNum=${version%-*}
           versionRC=${version#$versionNum}
           versionRC=${versionRC//[-.]/}
+          versionRC=${versionRC//alpha/a}
+          versionRC=${versionRC//beta/b}
           currentVersion="${versionNum}${versionRC}"
 
           pip install --upgrade pip


### PR DESCRIPTION
Add support for formatting alpha and beta versions in the release workflow. This change ensures that versions like `1.2.3-alpha.1` and `1.2.3-beta.1` are correctly formatted to `1.2.3a1` and `1.2.3b1`, respectively.

Fix also the package name of `chronicler` to `grimoirelab-chronicler`.