### PR TITLE
Add codespell support with configuration and fixes

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/NEWS
+++ b/NEWS
@@ -753,7 +753,7 @@ The following list describes the changes by component:
 
  * Enforce merge recommendation integrity (#993)\
    Ensure merge recommendations are unique between individuals and
-   prevent creating recommmendations with the same individual.
+   prevent creating recommendations with the same individual.
  * Automatic affiliation fixed and reduced results (#994)\
    Fixes a bug that caused running the affiliate process to overwrite
    existing affiliation dates. Now, the job result only includes
@@ -860,7 +860,7 @@ The following list describes the changes by component:
    The item types for pull requests in the GitHub indices had different
    values. While in `github_pull_requests` the type was `pull request`,
    the type in `github2_pull_request` was `pull_request` (with
-   underscore). We have fixed this bug unifing the type to
+   underscore). We have fixed this bug unifying the type to
    `pull_request`. You will have to re-enrich indices in your instance to
    update old items.
  * Sync AOC and Git raw indexes error\
@@ -1365,7 +1365,7 @@ The following list describes the changes by component:
 **Bug fixes:**
 
  * GitHub incremental collection date\
-   GitHub incremantal collection was not working correctly because of an
+   GitHub incremental collection was not working correctly because of an
    inconsistence between the default dates in Perceval and ELK.
 
 ### sirmordred
@@ -1912,7 +1912,7 @@ The following list describes the changes by component:
  * Keywords data on enriched items\
    Keywords field is included now on the enriched items of bugzilla and
    bugzillarest indices.
- * New reponse times on bugzilla items\
+ * New response times on bugzilla items\
    The Bugzilla enriched items include two new fields to track response
    times on these type of repositories. The field
    `time_to_first_attention` is the the time expressed in days between
@@ -2293,12 +2293,12 @@ The following list describes the changes by component:
  * Refetch general settings after they are changed\
    The "unify" and "affiliate" switches on the general settings page
    sometimes reflected outdated information. The page now reloads the
-   data everytime it is visited to keep it updated.
+   data every time it is visited to keep it updated.
 
 **Dependencies updateds:**
 
  * Migration to Vue 3\
-   Vue 2 reached end of life on December 2023 and is no longer mantained.
+   Vue 2 reached end of life on December 2023 and is no longer maintained.
 
 ### cereslib
   
@@ -2472,7 +2472,7 @@ The following list describes the changes by component:
 **Dependencies updateds:**
 
  * Drop support of Node.js <18\
-   Versions 14 to 16 of Node.js are no longer mantained. The current
+   Versions 14 to 16 of Node.js are no longer maintained. The current
    supported versions are 18 to 20.
 
 ### cereslib
@@ -2542,7 +2542,7 @@ The following list describes the changes by component:
    one of its aliases returns the organization. When an organization is
    merged into another, its name becomes an alias of the target
    organization. If a name exists as an alias, no organization can be
-   created with that name and viceversa. An organization's aliases can be
+   created with that name and vice-versa. An organization's aliases can be
    added and deleted both on the organizations table and the single
    organization view.
 
@@ -3005,7 +3005,7 @@ The following list describes the changes by component:
    dashboard.
  * Cache individuals table data (#821)\
    Using cached queries prevents the table from refetching all the data
-   from the server everytime any information is edited. This is
+   from the server every time any information is edited. This is
    particularly helpful if there is a huge number of identities, where
    reloading the table is very slow. However, there are some cases when
    the queries need to be refetched, eg. when identities are merged or
@@ -3104,7 +3104,7 @@ The following list describes the changes by component:
 **New features:**
 
  * Strict criteria for merge recommendations (#812)\
-   The merge recommendations filter out invalid email adresses and names
+   The merge recommendations filter out invalid email addresses and names
    that don't have at least a first and last name  when looking for
    matches. To disable this behavior, set the `strict` parameter on
    `recommendMatches` or `unify` to `false`.
@@ -3548,7 +3548,7 @@ The following list describes the changes by component:
 
  * Show hidden buttons when the mouse is over the table row (#787)\
    The buttons to lock an individual or mark it as a bot were only
-   visible when the mouse wass over the individual's name, which made it
+   visible when the mouse was over the individual's name, which made it
    hard to find them. Now they appear when the mouse is over the table
    row.
  * Email affiliation error (#793)\
@@ -3869,7 +3869,7 @@ The following list describes the changes by component:
  * Set top domain from UI (#729)\
    Add the option to set an organization's domain as top domain from the
    UI.
- * Order individuals by indentities (#732)\
+ * Order individuals by identities (#732)\
    Adds the option to order the individuals by the number of identities
    they have.
  * Import identities automatically (#746)\
@@ -3889,7 +3889,7 @@ The following list describes the changes by component:
  * Drag and drop to enroll in teams\
    Expanding an organization on the table now shows the full list of
    teams. Individuals can be dragged and dropped into a team and
-   viceversa to affiliate them. The buttons to add, edit and delete
+   vice-versa to affiliate them. The buttons to add, edit and delete
    organization and team information are reorganized into a dropdown menu
    to simplify the interface.
  * Multi-tenancy mode\
@@ -4467,6 +4467,6 @@ The following list describes the changes by component:
  * Add studies to the alias file\
    Add onion, areas of code, and demographics studies to the file
    aliases.json. This is needed to keep this file updated with the
-   aliases we use in the dashboards by adding them to the appropiate data
+   aliases we use in the dashboards by adding them to the appropriate data
    sources. The included aliases: - all_onion - git_areas_of_code -
    demographics

--- a/NEWS
+++ b/NEWS
@@ -4375,7 +4375,7 @@ The following list describes the changes by component:
 
  * Fix error in update worktree\
    Graal wasn't working with the latest version of Git 2.35.1 because it
-   protects braches checked out in all worktrees. This change renames the
+   protects branches checked out in all worktrees. This change renames the
    branch created when creating a worktree to fix the issue.
    
 ### Sorting Hat

--- a/community_components.md
+++ b/community_components.md
@@ -39,7 +39,7 @@ for retrieving data from some of its data sources.
 * [Q-DashMan](https://github.com/zhquan/TFM/)
 by [Quan Zhou](https://github.com/zhquan).
 Master thesis which consists of a completely automated system that provides
-a web interface for configuring GrimoireLab, so that it analyizes any set of
+a web interface for configuring GrimoireLab, so that it analyzes any set of
 repositories.
 
 * [Prosoul](https://github.com/Bitergia/prosoul)

--- a/docs/_data/projects.yml
+++ b/docs/_data/projects.yml
@@ -7,7 +7,7 @@
   description: Graal leverages on the Git backend of Perceval and enhances it to set up ad-hoc source code analysis. Thus, it fetches the commits from a Git repository and provides a mechanism to plug third party tools/libraries focused on source code analysis.
 - name: Arthur
   github-name: grimoirelab-kingarthur
-  description: <em>King Arthur</em> commands his loyal knight <em>Sir Perceval</em> mananging the tasks to retrieve data for analysis. It manages data incremental update, parallel downloading, etc.
+  description: <em>King Arthur</em> commands his loyal knight <em>Sir Perceval</em> managing the tasks to retrieve data for analysis. It manages data incremental update, parallel downloading, etc.
 - name: GrimoireELK
   github-name: grimoirelab-elk
   description: <em>Playground</em> for testing the whole set of tools as a platform for software development analytics. It's is a prototype of the <em>Grimoire Open Development Analytics</em> platform.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,3 +57,10 @@ perceval = {version = ">=1.4.6", allow-prereleases = true}
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git,.gitignore,.gitattributes,*.pdf,*.svg,*.lock,*.css,*.min.*'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git,.gitignore,.gitattributes,*.pdf,*.svg,*.lock,*.css,*.min.*'
+skip = '.git,.gitignore,.gitattributes,*.pdf,*.svg,*.lock,*.css,*.min.*,.cache,.npm,./docs/ar/js/*,./kubernetes/*'
 check-hidden = true
-# ignore-regex = ''
-# ignore-words-list = ''
+# hace - Spanish time expressions in historical changelogs ("hace 52 minutos")
+ignore-words-list = 'hace'

--- a/releases/0.11.0-rc.1.md
+++ b/releases/0.11.0-rc.1.md
@@ -25,7 +25,7 @@ The following list describes the changes by component:
 
  * Show hidden buttons when the mouse is over the table row (#787)\
    The buttons to lock an individual or mark it as a bot were only
-   visible when the mouse wass over the individual's name, which made it
+   visible when the mouse was over the individual's name, which made it
    hard to find them. Now they appear when the mouse is over the table
    row.
  * Email affiliation error (#793)\

--- a/releases/0.11.0.md
+++ b/releases/0.11.0.md
@@ -21,7 +21,7 @@ The following list describes the changes by component:
 
  * Show hidden buttons when the mouse is over the table row (#787)\
    The buttons to lock an individual or mark it as a bot were only
-   visible when the mouse wass over the individual's name, which made it
+   visible when the mouse was over the individual's name, which made it
    hard to find them. Now they appear when the mouse is over the table
    row.
  * Email affiliation error (#793)\

--- a/releases/0.15.0.md
+++ b/releases/0.15.0.md
@@ -29,7 +29,7 @@ The following list describes the changes by component:
 **New features:**
 
  * Strict criteria for merge recommendations (#812)\
-   The merge recommendations filter out invalid email adresses and names
+   The merge recommendations filter out invalid email addresses and names
    that don't have at least a first and last name  when looking for
    matches. To disable this behavior, set the `strict` parameter on
    `recommendMatches` or `unify` to `false`.

--- a/releases/0.16.0-rc.1.md
+++ b/releases/0.16.0-rc.1.md
@@ -19,7 +19,7 @@ The following list describes the changes by component:
    dashboard.
  * Cache individuals table data (#821)\
    Using cached queries prevents the table from refetching all the data
-   from the server everytime any information is edited. This is
+   from the server every time any information is edited. This is
    particularly helpful if there is a huge number of identities, where
    reloading the table is very slow. However, there are some cases when
    the queries need to be refetched, eg. when identities are merged or

--- a/releases/0.16.0.md
+++ b/releases/0.16.0.md
@@ -19,7 +19,7 @@ The following list describes the changes by component:
    dashboard.
  * Cache individuals table data (#821)\
    Using cached queries prevents the table from refetching all the data
-   from the server everytime any information is edited. This is
+   from the server every time any information is edited. This is
    particularly helpful if there is a huge number of identities, where
    reloading the table is very slow. However, there are some cases when
    the queries need to be refetched, eg. when identities are merged or

--- a/releases/0.21.0-rc.1.md
+++ b/releases/0.21.0-rc.1.md
@@ -13,7 +13,7 @@ The following list describes the changes by component:
    one of its aliases returns the organization. When an organization is
    merged into another, its name becomes an alias of the target
    organization. If a name exists as an alias, no organization can be
-   created with that name and viceversa. An organization's aliases can be
+   created with that name and vice-versa. An organization's aliases can be
    added and deleted both on the organizations table and the single
    organization view.
 

--- a/releases/0.21.0.md
+++ b/releases/0.21.0.md
@@ -13,7 +13,7 @@ The following list describes the changes by component:
    one of its aliases returns the organization. When an organization is
    merged into another, its name becomes an alias of the target
    organization. If a name exists as an alias, no organization can be
-   created with that name and viceversa. An organization's aliases can be
+   created with that name and vice-versa. An organization's aliases can be
    added and deleted both on the organizations table and the single
    organization view.
 

--- a/releases/0.22.0-rc.1.md
+++ b/releases/0.22.0-rc.1.md
@@ -28,7 +28,7 @@ The following list describes the changes by component:
 **Dependencies updateds:**
 
  * Drop support of Node.js <18\
-   Versions 14 to 16 of Node.js are no longer mantained. The current
+   Versions 14 to 16 of Node.js are no longer maintained. The current
    supported versions are 18 to 20.
 
   ## cereslib 0.5.4-rc.1 - (2024-03-01)

--- a/releases/0.22.0.md
+++ b/releases/0.22.0.md
@@ -28,7 +28,7 @@ The following list describes the changes by component:
 **Dependencies updateds:**
 
  * Drop support of Node.js <18\
-   Versions 14 to 16 of Node.js are no longer mantained. The current
+   Versions 14 to 16 of Node.js are no longer maintained. The current
    supported versions are 18 to 20.
 
   ## cereslib 0.5.4 - (2024-03-01)

--- a/releases/0.24.0-rc.1.md
+++ b/releases/0.24.0-rc.1.md
@@ -14,12 +14,12 @@ The following list describes the changes by component:
  * Refetch general settings after they are changed\
    The "unify" and "affiliate" switches on the general settings page
    sometimes reflected outdated information. The page now reloads the
-   data everytime it is visited to keep it updated.
+   data every time it is visited to keep it updated.
 
 **Dependencies updateds:**
 
  * Migration to Vue 3\
-   Vue 2 reached end of life on December 2023 and is no longer mantained.
+   Vue 2 reached end of life on December 2023 and is no longer maintained.
 
   ## cereslib 0.5.6-rc.1 - (2024-03-27)
   

--- a/releases/0.24.0.md
+++ b/releases/0.24.0.md
@@ -14,12 +14,12 @@ The following list describes the changes by component:
  * Refetch general settings after they are changed\
    The "unify" and "affiliate" switches on the general settings page
    sometimes reflected outdated information. The page now reloads the
-   data everytime it is visited to keep it updated.
+   data every time it is visited to keep it updated.
 
 **Dependencies updateds:**
 
  * Migration to Vue 3\
-   Vue 2 reached end of life on December 2023 and is no longer mantained.
+   Vue 2 reached end of life on December 2023 and is no longer maintained.
 
   ## cereslib 0.5.6 - (2024-03-27)
   

--- a/releases/0.3.0.md
+++ b/releases/0.3.0.md
@@ -141,6 +141,6 @@ The following list describes the changes by component:
  * Add studies to the alias file\
    Add onion, areas of code, and demographics studies to the file
    aliases.json. This is needed to keep this file updated with the
-   aliases we use in the dashboards by adding them to the appropiate data
+   aliases we use in the dashboards by adding them to the appropriate data
    sources. The included aliases: - all_onion - git_areas_of_code -
    demographics

--- a/releases/0.3.0.md
+++ b/releases/0.3.0.md
@@ -49,7 +49,7 @@ The following list describes the changes by component:
 
  * Fix error in update worktree\
    Graal wasn't working with the latest version of Git 2.35.1 because it
-   protects braches checked out in all worktrees. This change renames the
+   protects branches checked out in all worktrees. This change renames the
    branch created when creating a worktree to fix the issue.
    
 ### Sorting Hat

--- a/releases/0.9.0.md
+++ b/releases/0.9.0.md
@@ -14,7 +14,7 @@ The following list describes the changes by component:
  * Set top domain from UI (#729)\
    Add the option to set an organization's domain as top domain from the
    UI.
- * Order individuals by indentities (#732)\
+ * Order individuals by identities (#732)\
    Adds the option to order the individuals by the number of identities
    they have.
  * Import identities automatically (#746)\
@@ -34,7 +34,7 @@ The following list describes the changes by component:
  * Drag and drop to enroll in teams\
    Expanding an organization on the table now shows the full list of
    teams. Individuals can be dragged and dropped into a team and
-   viceversa to affiliate them. The buttons to add, edit and delete
+   vice-versa to affiliate them. The buttons to add, edit and delete
    organization and team information are reorganized into a dropdown menu
    to simplify the interface.
  * Multi-tenancy mode\

--- a/releases/1.0.0-rc.4.md
+++ b/releases/1.0.0-rc.4.md
@@ -16,7 +16,7 @@ The following list describes the changes by component:
 
  * Django version updated\
    Upgrade the Django version from 3.2 to 4.2. Support for Django 3.2
-   ended at April 1, 2024. This change ensures compability with the
+   ended at April 1, 2024. This change ensures compatibility with the
    latests features and an extended support.
 
 

--- a/releases/1.12.0-rc.1.md
+++ b/releases/1.12.0-rc.1.md
@@ -36,7 +36,7 @@ The following list describes the changes by component:
 **Bug fixes:**
 
  * GitHub incremental collection date\
-   GitHub incremantal collection was not working correctly because of an
+   GitHub incremental collection was not working correctly because of an
    inconsistence between the default dates in Perceval and ELK.
 
   ## sirmordred 1.1.9-rc.1 - (2025-05-20)

--- a/releases/1.12.0.md
+++ b/releases/1.12.0.md
@@ -50,7 +50,7 @@ The following list describes the changes by component:
 **Bug fixes:**
 
  * GitHub incremental collection date\
-   GitHub incremantal collection was not working correctly because of an
+   GitHub incremental collection was not working correctly because of an
    inconsistence between the default dates in Perceval and ELK.
 
   ## sirmordred 1.1.9 - (2025-05-20)

--- a/releases/1.16.0-rc.5.md
+++ b/releases/1.16.0-rc.5.md
@@ -9,7 +9,7 @@ The following list describes the changes by component:
 
  * Enforce merge recommendation integrity (#993)\
    Ensure merge recommendations are unique between individuals and
-   prevent creating recommmendations with the same individual.
+   prevent creating recommendations with the same individual.
  * Django static files configuration\
    Update the Django STORAGES setting for static files, ensuring
    compatibility with Django 5.2.

--- a/releases/1.16.0.md
+++ b/releases/1.16.0.md
@@ -36,7 +36,7 @@ The following list describes the changes by component:
 
  * Enforce merge recommendation integrity (#993)\
    Ensure merge recommendations are unique between individuals and
-   prevent creating recommmendations with the same individual.
+   prevent creating recommendations with the same individual.
  * Automatic affiliation fixed and reduced results (#994)\
    Fixes a bug that caused running the affiliate process to overwrite
    existing affiliation dates. Now, the job result only includes
@@ -142,7 +142,7 @@ The following list describes the changes by component:
    The item types for pull requests in the GitHub indices had different
    values. While in `github_pull_requests` the type was `pull request`,
    the type in `github2_pull_request` was `pull_request` (with
-   underscore). We have fixed this bug unifing the type to
+   underscore). We have fixed this bug unifying the type to
    `pull_request`. You will have to re-enrich indices in your instance to
    update old items.
  * Sync AOC and Git raw indexes error\

--- a/releases/1.7.0-rc.1.md
+++ b/releases/1.7.0-rc.1.md
@@ -57,7 +57,7 @@ The following list describes the changes by component:
  * Keywords data on enriched items\
    Keywords field is included now on the enriched items of bugzilla and
    bugzillarest indices.
- * New reponse times on bugzilla items\
+ * New response times on bugzilla items\
    The Bugzilla enriched items include two new fields to track response
    times on these type of repositories. The field
    `time_to_first_attention` is the the time expressed in days between

--- a/releases/1.7.0.md
+++ b/releases/1.7.0.md
@@ -57,7 +57,7 @@ The following list describes the changes by component:
  * Keywords data on enriched items\
    Keywords field is included now on the enriched items of bugzilla and
    bugzillarest indices.
- * New reponse times on bugzilla items\
+ * New response times on bugzilla items\
    The Bugzilla enriched items include two new fields to track response
    times on these type of repositories. The field
    `time_to_first_attention` is the the time expressed in days between

--- a/releases/old/NEWS
+++ b/releases/old/NEWS
@@ -730,7 +730,7 @@ Released: 2020-04-24
     * [mordred] Add support for github events
     * [doc-git] Add parameter `run_month_days` in `enrich_git_branches`
     * This commit adds config, alias, menu entry and documentaion for gitter backend.
-    * Fixed the typoes of docker/README.md
+    * Fixed the typos of docker/README.md
     * [doc] Add Pagure datasource
     * [tests] Remove user/password from es_enrichment section
     * Remove user and password parameter from elastic section
@@ -828,7 +828,7 @@ Released: 2020-03-20
     * fixed username and pass for kibiter login
     * Update README.md troubleshooting section - processes conflict with SearchGuard
     * Update README.md troubleshooting section - processes conflict with SearchGuard
-    * Update 'Source code and docker' section of README.md to include unsecure docker-compose
+    * Update 'Source code and docker' section of README.md to include insecure docker-compose
     * correcting spelling mistakes in Readme
     * Added Empty Index Problem with Solution in troubleshooting section of Readme
     * [utils] Add script to upload menu and dashboards
@@ -1420,7 +1420,7 @@ Released: 2019-10-28
     * [studies] Improve log messages
     * [task_enrich] Remove support for filter-raw-prefix
     * [task] Remove support for filter-raw-prefix
-    * [task_manager] Conver INFO messages to DEBUG
+    * [task_manager] Convert INFO messages to DEBUG
     * [task_enrich] Standardize refresh identities log messages
     * [sirmordred] Improve log messages related to task projects
     * [mordred] Ignore INFO messages from elasticsearch
@@ -1527,7 +1527,7 @@ Released: 2019-09-02
     * [schema] Remove ocean-unique-id
     * [raw-askbot] Remove fix_item
     * [tests] Add main to test_load_identities
-    * [jenkins] Remove ocean-unique-id frmo schema
+    * [jenkins] Remove ocean-unique-id from schema
     * [Jenkins] Update CSV schema for Jenkins
 * Perceval
     * [groupsio] Replace HTTP basic auth with cookies based auth (hace 52 minutos)

--- a/releases/old/NEWS
+++ b/releases/old/NEWS
@@ -53,7 +53,7 @@ Released: 2022-03-18
 * SirMordred
     * [gha] Use poetry for tests in GitHub Actions workflow
     * [poetry] Add poetry support
-    * [deps] Fix dependecies in requirements
+    * [deps] Fix dependencies in requirements
     * [utils] Change sirmordred scripts as entrypoints
     * Refactoring link to new tutorial page. Currently it links to a page not found and I'm pretty sure this is a better place for the reader to be sent.
     * Clarify README
@@ -538,7 +538,7 @@ Released: 2020-07-27
 
 * GrimoireLab
     * Remove 'manuscripts' from the release due there is
-      a broken depencency with matplotlib and numpy.
+      a broken dependency with matplotlib and numpy.
 
 
 # 0.2.44
@@ -707,7 +707,7 @@ Released: 2020-04-24
     * [mattermost] Add sanitize for archive
     * [github] Add sanitize for archive
     * [discourse] Add sanitize for archive
-    * [backend] Add predefined paramaters to clients
+    * [backend] Add predefined parameters to clients
     * [pagure] Fix failing tests
     * [backend] Add Gitter backend
     * [gerrit] Extend `--start` param to gerrit 3.x
@@ -729,7 +729,7 @@ Released: 2020-04-24
 * Mordred
     * [mordred] Add support for github events
     * [doc-git] Add parameter `run_month_days` in `enrich_git_branches`
-    * This commit adds config, alias, menu entry and documentaion for gitter backend.
+    * This commit adds config, alias, menu entry and documentation for gitter backend.
     * Fixed the typos of docker/README.md
     * [doc] Add Pagure datasource
     * [tests] Remove user/password from es_enrichment section
@@ -772,7 +772,7 @@ Released: 2020-04-24
     * [ELK] Store and process github events
     * [enrich-git] Add the param `run_month_days` to enrich_git_branches
     * [enriched-git] Handle connection problems during enrich_git_branches
-    * This commit addds support for gitter backend. Raw and Enriched indexes have been added along with their tests and schemas.
+    * This commit adds support for gitter backend. Raw and Enriched indexes have been added along with their tests and schemas.
     * [pagure] Add support for Pagure
     * updated the docstring for pair_programming
     * [enriched-bugzillarest] Add new field `is_open`
@@ -1156,7 +1156,7 @@ Released: 2019-12-19
     * [engagement panel] Fix dashboard name
     * [colic] Fix dashboard name
     * [cocom] Fix dashboard name
-    * Fix file name to use hypens instead of underscores
+    * Fix file name to use hyphens instead of underscores
     * [github_issues] Retitle issues open to issues
     * [gitlab_issues] Retitle issues open to issues
     * [about] Add mention to CHAOSS project
@@ -1412,7 +1412,7 @@ Released: 2019-10-28
 
 * SirMordred
     * [task_identities] Call sh affiliate after loading identities file
-    * [task_identities] Call sh unify after loading identites file
+    * [task_identities] Call sh unify after loading identities file
     * [travis] Support tests for python 3.5 and 3.6
     * [tests]  Add tests for enrich_extra_data study
     * [doc] Improve desc projects_url
@@ -1566,9 +1566,9 @@ Released: 2019-08-29
     * [colic] Filter dir paths from analysis
     * [analyzer] Add `diff_timeout` param to cloc analyzer
     * [analyzers] Suppress deprecation warning lizard.analyze_file
-    * [docs] Update CoLic definition under documentation adn docstrings
+    * [docs] Update CoLic definition under documentation and docstrings
     * [colic] Add copyright flag for extraction of copyright information
-    * [cloc] Fix cloc error due to mulitple word language-name
+    * [cloc] Fix cloc error due to multiple word language-name
     * [graal] Update license info
     * [setup] Fix format type for long description of package
     * [tests] Fix test_init in test_graal
@@ -1629,7 +1629,7 @@ Released: 2019-07-23
     * [tests] Fix server tests with non-real repositories
     * [server] Publish task information
     * [tasks] Use datetime_utcnow() when creating tasks
-    * [jobs] Add funtion to convert job results to dicts
+    * [jobs] Add function to convert job results to dicts
     * [scheduler] Set infinite time-to-live for jobs and results
     * [scheduler] Update task jobs list when a job is enqueued
     * [tasks] Add attribute to Task to store its list of jobs
@@ -1921,7 +1921,7 @@ Released: 2019-04-22
     * [enriched] Add metadata filter raw to enriched items
     * [elk] Use filter raw info to assess last enrich date
     * [enriched-enrich] Add `metadata_filter_raw` method
-    * [enriched-utils] Add filter raw text to retrive last enrich date
+    * [enriched-utils] Add filter raw text to retrieve last enrich date
     * [enriched-utils] Fix last enrich date calculation
 * Perceval
     * [doc] Update help messages for "from-date" and "to-date" params
@@ -2050,7 +2050,7 @@ Released: 2019-03-26
 * SirMordred
     * [utils] Update setup.cfg and projects.json of micro-mordred
     * [task_panels] Order dashboards by name
-    * [doc] Update documention for panels section
+    * [doc] Update documentation for panels section
     * [menu.yml] Add export panel to Jenkins
     * [task_panels] Upload github repos panels
     * [tests] Update aliases.json in tests folder

--- a/releases/old/NEWS.old
+++ b/releases/old/NEWS.old
@@ -408,7 +408,7 @@ Released: 2018-08-23
 ** Use 'edits' instead of 'editions' for MediaWiki
 ** [mattermost] Add Kibana 6 panel and index pattern
 ** [reps activities] Add panel migrated to Kibana 6
-** [reps events] add panel fro Kibana 6
+** [reps events] add panel for Kibana 6
 ** [about] Add about.json from master
 ** [dockerhub] Fix legend title for Stars and Pulls
 ** [dockerhub] Update evolutionary charts to use Timelion and use Deltas
@@ -2127,7 +2127,7 @@ Released: 2017-11-30
 ** [enrich][functest] Implement get_field_author and return None
 ** [enrich][twitter] Check that twitter is in projects map before using it
 ** [enrich][bugzillarest] Change fields to use the same names than in bugzilla
-** [enrich][bugzilla] Remove project_name field to avoid confussions with dashboard projects
+** [enrich][bugzilla] Remove project_name field to avoid confusions with dashboard projects
 ** [ocean][phabricator] Fix to float the subpriority field
 ** [enrich] Check if an identity exists before trying to get her profile
 ** [index_mapping] Support sort-after scrolling. Use sync uploading of bulk data
@@ -2441,7 +2441,7 @@ Released: 2017-10-20
 ** [task_panels] Fix mapping problem with ElasticSearch/Kibana 5.6
 ** [task_identities] Set TaskInitSortingHat as a global task not related to a data source
 ** [task_panel][aliases] Add functest aliases
-** [tasks] Readd support to execute one time all tasks and exit.
+** [tasks] Re-add support to execute one time all tasks and exit.
 ** [task_panels] Add missing aliases: apache, google-hits, remo-events
 ** Adapt to produce a pipy package (remove VIzGrimoireUtils dependency)
 

--- a/releases/old/NEWS.old
+++ b/releases/old/NEWS.old
@@ -22,11 +22,11 @@ Released: 2018-11-06
 ** [utils] Goodbye rest script
 ** [enrich-gitlab] Handle missing milestone attribute in raw items
 ** [elastic_items] Refactor `fetch` method
-** [enrich-google_hits] Redifine has_identities method
-** [enrich-functest] Redifine has_identities method
-** [enrich-dockerhub] Redifine has_identities method
-** [enrich-jenkins] Redifine has_identities method
-** [elk] Add condition to skip loading identites
+** [enrich-google_hits] Redefine has_identities method
+** [enrich-functest] Redefine has_identities method
+** [enrich-dockerhub] Redefine has_identities method
+** [enrich-jenkins] Redefine has_identities method
+** [elk] Add condition to skip loading identities
 ** [enrich] Add has_identities method
 ** [enrich-askbot] Replace list with yield
 ** [enrich-bugzillarest] Replace list with yield
@@ -487,7 +487,7 @@ Released: 2018-08-23
 ** [docker] Remove gunicorn and use stage from Docker image
 ** [docker] Modify apache config to serve static files and generate the static files during deployment
 ** [static] Reorganize static contents for the base template in the django-hatstall project
-** [urls] Remove gunicorn suport for static contents
+** [urls] Remove gunicorn support for static contents
 ** [docker] Add in stage the activation of ssl module in Apache
 ** [docker] Support https for accessing the Django Hatstall application
 ** [docker] Convert Django Hatstall deployment to Apache2 + mod_wsgi
@@ -981,7 +981,7 @@ Released: 2018-05-17
 * Mordred
 
 * grimoirelab-elk
-** [enrich][twitter] Use case insesitive tags for doing the projects mapping
+** [enrich][twitter] Use case insensitive tags for doing the projects mapping
 ** [studies][demography] Add tests for the study
 ** [studies][demography] Use author_id field to aggregate the authors instead of Author
 
@@ -1098,9 +1098,9 @@ Released: 2018-04-18
 * grimoirelab-elk
 ** [jenkins] Update raw mappings to deal with large comments
 ** [jira] Handle data.changelog.histories fields
-** [tests] Update test load identites
+** [tests] Update test load identities
 ** [elk] load identities by bulks to sortinghat
-** [sortinghat_gelk] Handle possible exeception when adding identities
+** [sortinghat_gelk] Handle possible exception when adding identities
 * Sigils (old panels)
 * Manuscripts (old reports)
 ** [report] Show the perdiod names always as YY-Q[1-4] (16-Q4)
@@ -1137,7 +1137,7 @@ Released: 2018-04-14
 ** [[tests] Update archives after sanitizing archived data
 
 * grimoirelab-elk
-** [enrich][jira] Check that main_description field is not None before trunctating it
+** [enrich][jira] Check that main_description field is not None before truncating it
 ** [doc] Add information about alias to studies doc
 ** [studies] Add alias management to onion study
 ** [studies] Add alias management for areas of code
@@ -1474,7 +1474,7 @@ Released: 2018-03-20
 
 * Hatstall
 ** Add custom pagination in order to retrieve the data paginated
-** Add search box that searchs directly to the sh database
+** Add search box that searches directly to the sh database
 ** Fix last_modified field show in unique identities
 ** Add 'show' custom in order to get length of the table paginated
 ** Change button show entries for 'onchange' event in the select
@@ -1644,7 +1644,7 @@ Released: 2018-03-13
 
 * Kidash
 ** [kidash] Update elastic import from grimoire_elk
-** [import] Don't modify the height of visualizatons in dashboards from Kibana >= 6
+** [import] Don't modify the height of visualizations in dashboards from Kibana >= 6
 
 * GrimoireLab Toolkit
 ** Add support to run tests using setup.py file
@@ -1703,7 +1703,7 @@ Released: 2018-02-01
 ** [enrich][git] Add a new field git_author_domain with the email domain for the Author of the commit
 
 * Kidash
-** [import] Don't modify the height of visualizatons in dashboards from Kibana >= 6
+** [import] Don't modify the height of visualizations in dashboards from Kibana >= 6
 
 ## elasticgirl.30
 
@@ -2565,7 +2565,7 @@ Released: 2017-08-08
 ** [menu] Add Maniphest panels to menu
 ** [menu] Fix name of Bugzilla panels
 ** Change schedule to upload panels + menu in the initial phase
-** Fix wrong URL when trying to set up defaul time frame and index pattern
+** Fix wrong URL when trying to set up default time frame and index pattern
 ** Update menu according to latest 5.1.1 GrimoireLab panels
 
 * GrimoireELK
@@ -2723,7 +2723,7 @@ Released: 2017-07-06
 * GrimoireELK
 ** [enrich][functest] Add support for enriching FuncTest data source coming from OPNFV
 ** Change TZ so that it comes from author_date
-** [enrich][sortinghat] Suppport the autorefresh of identities using a list of ids or uuids in an enriched index
+** [enrich][sortinghat] Support the autorefresh of identities using a list of ids or uuids in an enriched index
 ** [enrich] Use always metadata__timestamp for detecting thew new items that must be enriched in incremental mode. Also do it for demography study.
 ** [panels] Add new method exists_dashboard to check if a dashboard already exists.
 ** [enrich][meetup] Use time_date as the grimoire_creation_date
@@ -2840,7 +2840,7 @@ Note: In this release we can not include perceval 0.8 because perceval-mozilla a
 * GrimoireLab Toolkit
 ** [uris] Add module for handling URIs
 ** [datetime] Add module for managing datatime objects
-** [introspect] Add module for handling instrospection
+** [introspect] Add module for handling introspection
 ** Release 0.1.0
 
 ## elasticgirl.7
@@ -2899,7 +2899,7 @@ Released: 2017-04-28
 ** [report] Get the active data sources in the mordred config file
 ** [report] Fix community section, GitHub metrics in overview, template string replacing in subdirs and quarter name.
 
-* VIzGrimoireUtils: added to the relase as mordred dependency
+* VIzGrimoireUtils: added to the release as mordred dependency
 ** [eclipse_projects] Break down eclipse_projects.py script in a library to be used for managing eclipse projects info and the script which uses it. The library is compatible with python2 and python3.
 
 ## elasticgirl.5.1
@@ -2927,7 +2927,7 @@ Released: 2017-04-21
 Released: 2017-04-10
 
 * SortingHat
-** [utils] Fix encoding error generting UUIDs in Python 3
+** [utils] Fix encoding error generating UUIDs in Python 3
 ** [mailmap2sh] Add tool to convert mailmap files to a Sorting Hat JSON
 
 * Perceval
@@ -2969,8 +2969,8 @@ Released: 2017-03-30
 ** Clean docker image and add support for reports (prettyplotlib and elasticsearch_dsl)
 ** Fixes in config params
 ** Check that there are tasks to execute in update mode before executing them to avoid infinite loop in update
-** Add new Task to track items upstream, including config and task implemetation.
-** Add new Task to generate reports including config and task implemetation.
+** Add new Task to track items upstream, including config and task implementation.
+** Add new Task to generate reports including config and task implementation.
 ** Add unaffiliated_group to configure the name of the unaffiliated org name
 
 * GrimoireELK


### PR DESCRIPTION
Add codespell configuration and fix existing typos.  You might ask why to fix typos in old NEWS? I would say -- why to cherish them there?

More about codespell: https://github.com/codespell-project/codespell

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

## Changes

### Configuration & Infrastructure
- Added `[tool.codespell]` section to `pyproject.toml`
- Created GitHub Actions workflow (`.github/workflows/codespell.yml`) to check spelling on push and PRs
- Configured to skip: `.cache`, `.npm`, `*.pdf`, `*.svg`, `*.css`, `*.lock`, `*.min.*`, `docs/ar/js/*` (vendored aframedc.js), `kubernetes/*` (org config with company names like Absolut, Conexant, Grammer, Synopsys, Infor)

### Domain-Specific Whitelist
- `hace` — Spanish time expressions in historical changelogs ("hace 52 minutos", "hace 3 días")

### Typo Fixes

**Ambiguous typos fixed manually** (8 fixes with context review):
- `braches` → `branches` (NEWS, releases/0.3.0.md) — git worktree context
- `typoes` → `typos` (releases/old/NEWS) — "Fixed the typos of docker/README.md"
- `Conver` → `Convert` (releases/old/NEWS) — "Convert INFO messages to DEBUG"
- `frmo` → `from` (releases/old/NEWS) — "Remove ocean-unique-id from schema"
- `unsecure` → `insecure` (releases/old/NEWS) — standard English term
- `fro` → `for` (releases/old/NEWS.old) — "add panel for Kibana 6"
- `confussions` → `confusions` (releases/old/NEWS.old) — "avoid confusions"
- `Readd` → `Re-add` (releases/old/NEWS.old) — "Re-add support to execute..."

**Non-ambiguous typos fixed automatically** (71 fixes in 25 files):
Common fixes include: `recommmendations` → `recommendations`, `mantained` → `maintained`, `everytime` → `every time`, `viceversa` → `vice-versa`, `incremantal` → `incremental`, `adresses` → `addresses`, `Redifine` → `Redefine`, `identites` → `identities`, `implemetation` → `implementation`, and many more across NEWS and release notes.

### Historical Context
This project has had 15 prior commits fixing typos manually, demonstrating the value of automated spell-checking.

## Testing

✅ Codespell passes with zero errors after all fixes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) and love to typos free code
